### PR TITLE
Delete 410 code for delete ops

### DIFF
--- a/Guidelines/ServiceAPIGuidelines.md
+++ b/Guidelines/ServiceAPIGuidelines.md
@@ -160,6 +160,7 @@ DELETE requests are used to delete resources. The semantic is best described as 
 
 * DELETE requests are usually applied to single resources, not on collection resources, as this would imply deleting the entire collection
 * successful DELETE requests will usually generate 200 (if the deleted resource is returned) or 204 (if no content is returned)
+* failed DELETE requests will usually generate 404 (if the resource cannot be found)
 
 # Schemas
 

--- a/Guidelines/ServiceAPIGuidelines.md
+++ b/Guidelines/ServiceAPIGuidelines.md
@@ -160,7 +160,6 @@ DELETE requests are used to delete resources. The semantic is best described as 
 
 * DELETE requests are usually applied to single resources, not on collection resources, as this would imply deleting the entire collection
 * successful DELETE requests will usually generate 200 (if the deleted resource is returned) or 204 (if no content is returned)
-* failed DELETE requests will usually generate 404 (if the resource cannot be found) or 410 (if the resource was already deleted before)
 
 # Schemas
 


### PR DESCRIPTION
We don't need an error code for already deleted objects. If the resource has been deleted we don't really know if it ever existed.
Discussed in #138