### PR TITLE
Fix server url in Swagger

### DIFF
--- a/services/ils/app/api/swagger/swagger.json
+++ b/services/ils/app/api/swagger/swagger.json
@@ -219,7 +219,7 @@
   },
   "servers": [
     {
-      "url": "http://integration-layer.openintegrationhub.com/"
+      "url": "http://ils.openintegrationhub.com/"
     },
     {
       "url": "http://localhost:3003/"


### PR DESCRIPTION
**What has changed?**

- Fix server url in Swagger to http://ils.openintegrationhub.com

**Does a specific change require especially careful review?** - No

[**Definition of Done**](https://github.com/openintegrationhub/openintegrationhub/blob/crudmonitoring/CONTRIBUTING.md#definition-of-done)
