### PR TITLE
Implement  ilaId name validation

### DIFF
--- a/services/ils/app/api/controllers/chunk.js
+++ b/services/ils/app/api/controllers/chunk.js
@@ -24,7 +24,7 @@ const {
   splitChunk,
   updateChunk,
   loadExternalSchema,
-  
+  ilaIdValidator,
 } = require('../utils/helpers');
 
 // Models
@@ -117,6 +117,17 @@ router.post('/', jsonParser, async (req, res) => {
   } = req.body;
   const { domainId, schema, schemaUri } = req.body.def;
   const invalidInputSchema = validateSchema(schema);
+
+  const validIlaId = await ilaIdValidator(ilaId);
+
+  if (validIlaId) {
+    return res.status(400).send(
+      {
+        errors:
+        [{ message: 'ilaId must not contain special characters!', code: 400 }],
+      },
+    );
+  }
 
   let payloadValidator;
 
@@ -242,6 +253,17 @@ router.post('/', jsonParser, async (req, res) => {
 router.post('/validate', jsonParser, async (req, res) => {
   const { payload, token, ilaId } = req.body;
   const valid = chunkValidator(req.body);
+
+  const validIlaId = await ilaIdValidator(ilaId);
+
+  if (validIlaId) {
+    return res.status(400).send(
+      {
+        errors:
+        [{ message: 'ilaId must not contain special characters!', code: 400 }],
+      },
+    );
+  }
 
   if (!token) {
     return res.status(401).send(

--- a/services/ils/app/api/controllers/chunk.js
+++ b/services/ils/app/api/controllers/chunk.js
@@ -19,7 +19,12 @@ const log = require('../../config/logger');
 
 const { validateSchema, validateSplitSchema } = require('../utils/validator');
 const {
-  createChunk, fetchSchema, splitChunk, updateChunk, loadExternalSchema,
+  createChunk,
+  fetchSchema,
+  splitChunk,
+  updateChunk,
+  loadExternalSchema,
+  
 } = require('../utils/helpers');
 
 // Models
@@ -162,7 +167,7 @@ router.post('/', jsonParser, async (req, res) => {
       );
     }
     try {
-      payloadValidator = ajv.compile(domainSchema.body.data.value);
+      payloadValidator = await ajv.compileAsync(domainSchema.body.data.value);
     } catch (e) {
       log.error('ERROR: ', e);
       return res.status(400).send(e);
@@ -175,7 +180,7 @@ router.post('/', jsonParser, async (req, res) => {
 
   if (schema) {
     try {
-      payloadValidator = ajv.compile(schema);
+      payloadValidator = await ajv.compileAsync(schema);
     } catch (e) {
       log.error('ERROR: ', e);
       return res.status(400).send(e);
@@ -235,7 +240,7 @@ router.post('/', jsonParser, async (req, res) => {
  * @return {Object} - object containing valid property and meta data
  */
 router.post('/validate', jsonParser, async (req, res) => {
-  const { payload, token } = req.body;
+  const { payload, token, ilaId } = req.body;
   const valid = chunkValidator(req.body);
 
   if (!token) {

--- a/services/ils/app/api/utils/helpers.js
+++ b/services/ils/app/api/utils/helpers.js
@@ -207,6 +207,22 @@ function loadExternalSchema(uri) {
   });
 }
 
+/**
+ * @desc ilaId name validation
+ *
+ * @param {String} ilaId - external schema uri
+ * @return {Boolean} - depending on regex result
+ */
+function ilaIdValidator(ilaId) {
+  const reg = /[' " / ~ > < & # \\ $ * ! ? + @ % ^ ( ),]/g;
+  return reg.test(ilaId);
+}
+
 module.exports = {
-  createChunk, updateChunk, splitChunk, fetchSchema, loadExternalSchema,
+  createChunk,
+  updateChunk,
+  splitChunk,
+  fetchSchema,
+  loadExternalSchema,
+  ilaIdValidator,
 };

--- a/services/ils/test/chunk.test.js
+++ b/services/ils/test/chunk.test.js
@@ -20,7 +20,7 @@ let app;
 const {
   chunk1, chunk2, chunk3, chunk4, chunk5, chunk6,
   chunk7, chunk8, chunk9, chunk10, chunk11, chunk12,
-  chunk13,
+  chunk13, chunk14,
 } = require('./seed/chunk.seed.js');
 const log = require('../app/config/logger');
 
@@ -86,6 +86,14 @@ describe('POST chunks', () => {
     expect(res.body.data.payload.firstName).toEqual('Jack');
     expect(res.body.data.payload.email).toEqual('hobbs@mail.com');
     expect(res.body.data.valid).toBeTruthy();
+  });
+
+  test('should return 400 if ilaId contains special characters', async () => {
+    const res = await request
+      .post('/chunks')
+      .send(chunk14);
+    expect(res.status).toEqual(400);
+    expect(res.body.errors[0].message).toEqual('ilaId must not contain special characters!');
   });
 
   test('should validate a valid SDF object', async () => {

--- a/services/ils/test/seed/chunk.seed.js
+++ b/services/ils/test/seed/chunk.seed.js
@@ -319,6 +319,21 @@ const chunk13 = {
   },
 };
 
+const chunk14 = {
+  ilaId: '/987asd@qwe!',
+  token: 'WXYUFOmgDdoniZatfaMTa4Ov-An98v2-4668x5fXOoLZS',
+  cid: 'email',
+  def: {
+    domainId: '5d3031a20cbe7c00115c7d8f',
+    schemaUri: 'address',
+  },
+  payload: {
+    lastName: 'Hobbs',
+    firstName: 'Jack',
+    email: 'hobbs@mail.com',
+  },
+};
+
 const createInvalidChunk = nock('http://metadata.openintegrationhub.com/api/v1/domains/5d3031a20cbe7c00115c7d8f/schemas/address')
   .get('')
   .reply(200, {
@@ -402,6 +417,7 @@ module.exports = {
   chunk11,
   chunk12,
   chunk13,
+  chunk14,
   createInvalidChunk,
   createValidChunk,
 };


### PR DESCRIPTION
**What has changed?**

- Create a helper function which validates `ilaId` name
- Add `await` to the Ajv compilation
- Implement `ilaId` name validation
---

[**Definition of Done**](https://github.com/openintegrationhub/openintegrationhub/blob/crudmonitoring/CONTRIBUTING.md#definition-of-done)
