### PR TITLE
allow secret sharing with other tenant users

### DIFF
--- a/lib/event-bus/package.json
+++ b/lib/event-bus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openintegrationhub/event-bus",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A library for working with the Event Bus",
   "main": "index.js",
   "scripts": {

--- a/lib/event-bus/src/events.js
+++ b/lib/event-bus/src/events.js
@@ -1,4 +1,12 @@
 module.exports = {
     'iam.user.deleted': 'iam.user.deleted',
     'iam.tenant.deleted': 'iam.tenant.deleted',
+
+    'secrets.secret.created': 'secrets.secret.created',
+    'secrets.token.get': 'secrets.token.get',
+    'secrets.secret.deleted': 'secrets.secret.deleted',
+    'secrets.secret.ownerAdded': 'secrets.secret.ownerAdded',
+    'secrets.secret.ownerRemoved': 'secrets.secret.ownerRemoved',
+    'secrets.authclient.created': 'secrets.authclient.created',
+    'secrets.authclient.deleted': 'secrets.authclient.deleted',
 };

--- a/lib/iam-utils/src/permissions.js
+++ b/lib/iam-utils/src/permissions.js
@@ -27,7 +27,6 @@ module.exports = {
 
         'iam.token.introspect': 'iam.token.introspect',
 
-        'secrets.raw.read': 'secrets.raw.read',
         'secrets.secret.deleteAny': 'secrets.secret.deleteAny',
         'secrets.authClient.deleteAny': 'secrets.authClient.deleteAny',
 

--- a/lib/secret-service/package.json
+++ b/lib/secret-service/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "@basaas/node-logger": "1.1.5",
-    "@openintegrationhub/event-bus": "1.0.2",
-    "@openintegrationhub/iam-utils": "1.4.1",
+    "@openintegrationhub/event-bus": "1.1.3",
+    "@openintegrationhub/iam-utils": "1.5.1",
     "assert": "2.0.0",
     "base64url": "3.0.1",
     "dot-prop": "5.1.0",

--- a/lib/secret-service/src/constant/permission.js
+++ b/lib/secret-service/src/constant/permission.js
@@ -1,10 +1,12 @@
+const { PERMISSIONS } = require('@openintegrationhub/iam-utils');
+
 module.exports = {
     restricted: {
-        secretDeleteAny: 'lynx.secret.delete', // 'lynx.secret.delete',
-        authClientDeleteAny: 'lynx.secret.delete', // 'lynx.secret.delete',
+        secretDeleteAny: PERMISSIONS.restricted["secrets.secret.deleteAny"],
+        authClientDeleteAny: PERMISSIONS.restricted["secrets.authClient.deleteAny"],
     },
     common: {
-        secretReadRaw: 'lynx.secret.read.raw', // 'lynx.secret.read.raw'
-        authClientReadRaw: 'lynx.auth.client.read.raw', // 'lynx.auth.client.read.raw'
+        secretReadRaw: PERMISSIONS.common["secrets.secret.readRaw"],
+        authClientReadRaw: PERMISSIONS.common["secrets.authClient.readRaw"],
     },
 };

--- a/lib/secret-service/src/dao/auth-client.js
+++ b/lib/secret-service/src/dao/auth-client.js
@@ -1,6 +1,6 @@
 const Logger = require('@basaas/node-logger');
 const AuthClient = require('../model/AuthClient');
-const { Event, EventBusManager } = require('@openintegrationhub/event-bus');
+const { Event, EventBusManager, events } = require('@openintegrationhub/event-bus');
 
 const conf = require('./../conf');
 
@@ -14,7 +14,7 @@ module.exports = {
         await client.save();
         const event = new Event({
             headers: {
-                name: 'secret-service.auth-client.created'
+                name: events["secrets.authclient.created"],
             },
             payload: {name: client.name}
         });
@@ -61,7 +61,7 @@ module.exports = {
             await toBeDeleted.save();
             const event = new Event({
                 headers: {
-                    name: 'secret-service.auth-client.deleted'
+                    name: events["secrets.authclient.deleted"],
                 },
                 payload: {client: id}
             });
@@ -71,7 +71,7 @@ module.exports = {
             await AuthClient.full.deleteOne({ _id: id });
             const event = new Event({
                 headers: {
-                    name: 'secret-service.auth-client.deleted'
+                    name: events["secrets.authclient.deleted"],
                 },
                 payload: {client: id}
             });
@@ -88,7 +88,7 @@ module.exports = {
                 await client.save();
                 const event = new Event({
                     headers: {
-                        name: 'secret-service.auth-client.deleted'
+                        name: events["secrets.authclient.deleted"],
                     },
                     payload: {client: client.id}
                 });
@@ -98,7 +98,7 @@ module.exports = {
                 await AuthClient.full.deleteOne({ _id: client._id });
                 const event = new Event({
                     headers: {
-                        name: 'secret-service.auth-client.deleted'
+                        name: events["secrets.authclient.deleted"],
                     },
                     payload: {client: client.id}
                 });

--- a/lib/secret-service/src/dao/secret.js
+++ b/lib/secret-service/src/dao/secret.js
@@ -5,9 +5,11 @@ const crypto = require('../util/crypto');
 const { OA2_AUTHORIZATION_CODE } = require('../constant').AUTH_TYPE;
 const { ENCRYPT, DECRYPT } = require('../constant').CRYPTO.METHODS;
 const { SENSITIVE_FIELDS } = require('../constant').CRYPTO;
+const { ENTITY_TYPE } = require('../constant');
 const authFlowManager = require('../auth-flow-manager');
 const AuthClientDAO = require('../dao/auth-client');
-const { Event, EventBusManager } = require('@openintegrationhub/event-bus');
+const { Event, EventBusManager, events } = require('@openintegrationhub/event-bus');
+const { isTenantAdmin } = require('@openintegrationhub/iam-utils');
 
 const Secret = require('../model/Secret');
 const conf = require('../conf');
@@ -135,7 +137,7 @@ module.exports = {
         auditLog.info('secret.created', { id: secret._id });
         const event = new Event({
             headers: {
-                name: 'secret-service.secret.created'
+                name: events["secrets.secret.created"],
             },
             payload: {name: secret.name}
         });
@@ -153,7 +155,7 @@ module.exports = {
             ? cryptoSecret(_secret, key, DECRYPT, ['accessToken']) : _secret;
             const event = new Event({
                 headers: {
-                    name: 'secret-service.token.get'
+                    name: events["secrets.token.get"],
                 },
                 payload: {message: 'requested RAW Token'}
             });
@@ -161,12 +163,13 @@ module.exports = {
         return _secret;
     },
     async findByEntityWithPagination(
-        id,
+        requester,
         props,
     ) {
-        return await Secret.full.find({
-            'owners.id': id,
-        },
+        const query = {
+            owners: { $in: [{ id: requester.sub, type: ENTITY_TYPE.USER}, { id: requester.tenant, type: ENTITY_TYPE.TENANT }] },
+        };
+        return await Secret.full.find(query,
         'name type value.authClientId value.scope value.expires value.externalId owners',
         props);
     },
@@ -232,7 +235,7 @@ module.exports = {
                 .getEventBus()
                 .publish(new Event({
                     headers: {
-                        name: 'secret-service.secret.deleted'
+                        name: events["secrets.secret.deleted"],
                     },
                     payload: { id }
                 }));
@@ -254,7 +257,7 @@ module.exports = {
                     .getEventBus()
                     .publish(new Event({
                         headers: {
-                            name: 'secret-service.secret.deleted'
+                            name: events["secrets.secret.deleted"],
                         },
                         payload: { id: secret._id }
                     }));
@@ -276,6 +279,14 @@ module.exports = {
             new: true,
         }).lean();
         auditLog.info('secret.owner.added', { id, ownerId, type });
+        EventBusManager
+            .getEventBus()
+            .publish(new Event({
+                headers: {
+                    name: events["secrets.secret.ownerAdded"],
+                },
+                payload: { id, ownerId, type }
+            }));
         return modifiedSecret;
     },
 
@@ -295,6 +306,14 @@ module.exports = {
         }).lean();
 
         auditLog.info('secret.owner.removed', { id, ownerId, type });
+        EventBusManager
+            .getEventBus()
+            .publish(new Event({
+                headers: {
+                    name: events["secrets.secret.ownerRemoved"],
+                },
+                payload: { id, ownerId, type }
+            }));
 
         return modifiedSecret;
 

--- a/lib/secret-service/src/model/AuthClient/index.js
+++ b/lib/secret-service/src/model/AuthClient/index.js
@@ -14,6 +14,7 @@ const authClientBaseSchema = new Schema({
         type: [owner],
         required: true,
     },
+    tenant: String,
     preprocessor: String, // example: "preprocessor.google"
     type: {
         type: String,

--- a/lib/secret-service/src/model/Secret/index.js
+++ b/lib/secret-service/src/model/Secret/index.js
@@ -22,6 +22,7 @@ const secretBaseSchema = new Schema({
         type: [owner],
         required: true,
     },
+    tenant: String,
     type: {
         type: String,
         enum: Object.keys(AUTH_TYPE),

--- a/lib/secret-service/src/modules/event.js
+++ b/lib/secret-service/src/modules/event.js
@@ -20,7 +20,7 @@ class EventManager {
         });
 
         eventBus.subscribe('iam.tenant.deleted', async (event) => {
-            await SecretsDAO.deleteAll({ ownerId: event.payload.user, type: CONSTANTS.ENTITY_TYPE.TENANT });
+            await SecretsDAO.deleteAll({ ownerId: event.payload.tenant, type: CONSTANTS.ENTITY_TYPE.TENANT });
             await event.ack();
         });
 

--- a/lib/secret-service/src/modules/iam.js
+++ b/lib/secret-service/src/modules/iam.js
@@ -2,6 +2,7 @@ const iamLib = require('@openintegrationhub/iam-utils');
 
 const logger = require('@basaas/node-logger');
 const conf = require('../conf');
+const { ENTITY_TYPE } = require('../constant');
 
 const log = logger.getLogger(`${conf.logging.namespace}/auth`);
 const SecretDAO = require('../dao/secret');
@@ -25,7 +26,7 @@ async function userIsOwnerOf(dao, req, res, next) {
          *
          * */
         const userIsOwner = doc.owners.find(
-            elem => elem.id === req.user.sub,
+            elem => elem.id === req.user.sub || (elem.id === req.user.tenant && elem.type === ENTITY_TYPE.TENANT),
         );
 
         if (userIsOwner) {

--- a/lib/secret-service/src/route/auth-clients/index.js
+++ b/lib/secret-service/src/route/auth-clients/index.js
@@ -8,7 +8,7 @@ const AuthFlowDAO = require('../../dao/auth-flow');
 const { getKeyParameter } = require('../../middleware/key');
 const conf = require('../../conf');
 
-const { ROLE } = require('../../constant');
+const { ROLE, ENTITY_TYPE } = require('../../constant');
 const authFlowManager = require('../../auth-flow-manager');
 const Pagination = require('../../util/pagination');
 const { OA2_AUTHORIZATION_CODE } = require('../../constant').AUTH_TYPE;
@@ -87,8 +87,9 @@ class AuthClientRouter {
                             ...data,
                             owners: [{
                                 id: req.user.sub.toString(),
-                                type: ROLE.USER,
+                                type: ENTITY_TYPE.USER,
                             }],
+                            tenant: req.user.tenant,
                         }),
                         requester: req.user,
                     }),
@@ -117,6 +118,12 @@ class AuthClientRouter {
         this.router.patch('/:id', userIsOwnerOfAuthClient, async (req, res, next) => {
             const { data } = req.body;
             try {
+                if (data.owners && !data.owners.find(owner => owner.persistentEntry)) {
+                    const authClient = await AuthClientDAO.findOne({
+                        _id: req.params.id,
+                    });
+                    data.owners.push(authClient.owners.find(owner => owner.persistentEntry));
+                }
                 res.send({
                     data: maskAuthClient({
                         authClient: await AuthClientDAO.update({
@@ -153,11 +160,11 @@ class AuthClientRouter {
         });
 
         this.router.delete('/', can([restricted.authClientDeleteAny]), async (req, res, next) => {
-            const { userId, type } = req.query;
+            const { ownerId, type } = req.query;
 
             try {
                 await AuthClientDAO.deleteAll({
-                    ownerId: userId,
+                    ownerId,
                     type,
                 });
 

--- a/lib/secret-service/src/route/auth-clients/index.spec.js
+++ b/lib/secret-service/src/route/auth-clients/index.spec.js
@@ -3,6 +3,7 @@ const supertest = require('supertest');
 const qs = require('qs');
 const iamMock = require('../../test/iamMock');
 const conf = require('../../conf');
+const { ENTITY_TYPE } = require('../../constant');
 const Server = require('../../server');
 const token = require('../../test/tokens');
 const {
@@ -62,7 +63,7 @@ describe('auth-clients', () => {
             })
             .expect(200);
 
-        await request.post('/auth-clients')
+        const resp = await request.post('/auth-clients')
             .set(...global.userAuth1)
             .send({
                 data: {
@@ -85,6 +86,9 @@ describe('auth-clients', () => {
                 },
             })
             .expect(200);
+
+        expect(resp.body.data.owners.length).toEqual(1);
+        expect(resp.body.data.tenant).toBeDefined();
 
         await request.post('/auth-clients')
             .set(...global.userAuth1)
@@ -177,6 +181,8 @@ describe('auth-clients', () => {
             .expect(200)).body.data;
 
         expect(authClient.name).toEqual('test');
+        expect(authClient.owners.length).toEqual(1);
+        expect(authClient.tenant).toBeDefined();
     });
 
     test('Remove a platform oauth secret', async () => {
@@ -272,8 +278,15 @@ describe('auth-clients', () => {
 
         // service account has permissions
         await request.delete(`/auth-clients?${qs.stringify({
-            userId: token.userToken1.value.sub,
+            ownerId: token.userToken1.value.sub,
             type: token.userToken1.value.role,
+        })}`)
+            .set(...global.serviceAccount)
+            .expect(200);
+        // service account has permissions
+        await request.delete(`/auth-clients?${qs.stringify({
+            ownerId: token.userToken1.value.tenant,
+            type: ENTITY_TYPE.TENANT,
         })}`)
             .set(...global.serviceAccount)
             .expect(200);

--- a/lib/secret-service/src/route/secrets/index.js
+++ b/lib/secret-service/src/route/secrets/index.js
@@ -67,6 +67,21 @@ class SecretsRouter {
         return maskedSecret;
     }
 
+    ownersIsValid (owners, user) {
+        let tenantIdMismatch = null;
+        try {
+            if (owners && owners.length) {
+                tenantIdMismatch = owners.find(owner => owner.type === 'TENANT' && owner.id.toString() !== user.tenant.toString());
+            }
+        } catch (e) {
+            log.error(e);
+            tenantIdMismatch = 1;
+        }
+
+        return !tenantIdMismatch;
+
+    }
+
     setup() {
         const { can, userIsOwnerOfSecret } = this.iam;
 
@@ -78,7 +93,7 @@ class SecretsRouter {
                 res.set('Cache-Control', 'no-store, no-cache, must-revalidate, private');
                 res.send({
                     data: await SecretDAO.findByEntityWithPagination(
-                        req.user.sub,
+                        req.user,
                         pagination.props(),
                     ),
                     meta: {
@@ -96,6 +111,14 @@ class SecretsRouter {
         this.router.post('/', getKeyParameter, getKey, async (req, res, next) => {
             const { data } = req.body;
             try {
+
+                if (!this.ownersIsValid(data.owners, req.user)) {
+                    return next({
+                        status: 400,
+                        message: 'Owners is not valid',
+                    });
+                }
+
                 const owners = [{
                     id: req.user.sub.toString(),
                     type: ROLE.USER,
@@ -141,6 +164,14 @@ class SecretsRouter {
         this.router.patch('/:id', userIsOwnerOfSecret, getKeyParameter, getKey, async (req, res, next) => {
             const { data } = req.body;
             try {
+
+                if (!this.ownersIsValid(data.owners, req.user)) {
+                    return next({
+                        status: 400,
+                        message: 'Owners is not valid',
+                    });
+                }
+
                 res.send({
                     data: await SecretDAO.update({
                         id: req.params.id,

--- a/lib/secret-service/src/route/secrets/index.spec.js
+++ b/lib/secret-service/src/route/secrets/index.spec.js
@@ -352,6 +352,40 @@ describe('secrets', () => {
             .expect(401);
     });
 
+    test('Secrets can be shared with all tenant users', async () => {
+        const data = {
+            name: 'sharedSecret',
+            type: SIMPLE,
+            value: {
+                username: 'foo',
+                passphrase: 'bar',
+            },
+            owners: [
+                {
+                    id: dummyUsers.userToken1.value.tenant,
+                    type: 'TENANT',
+                }
+            ]
+        };
+
+        const { body } = await request.post('/secrets')
+            .set(...global.userAuth1)
+            .send({ data })
+            .expect(200);
+
+        const resp = (await request.get(`/secrets/${body.data._id}`)
+            .set(...global.userAuth1SecondUser)
+            .expect(200)).body;
+
+        expect(resp.data.name).toEqual(data.name);
+
+
+        await request.get(`/secrets/${body.data._id}`)
+            .set(...global.userAuth2)
+            .expect(403);
+
+    });
+
     test('Get the secret by id', async () => {
         const data = {
             name: 'string123',

--- a/lib/secret-service/src/test/mongo-environment.js
+++ b/lib/secret-service/src/test/mongo-environment.js
@@ -3,6 +3,7 @@ const path = require('path');
 const fs = require('fs');
 const {
     userToken1,
+    userAuth1SecondUser,
     adminToken1,
     adminToken2,
     userToken2,
@@ -26,6 +27,7 @@ module.exports = class MongoEnvironment extends NodeEnvironment {
         // setup auth header
         this.global.adminAuth1 = ['Authorization', `bearer ${adminToken1.token}`];
         this.global.userAuth1 = ['Authorization', `bearer ${userToken1.token}`];
+        this.global.userAuth1SecondUser = ['Authorization', `bearer ${userAuth1SecondUser.token}`];
         this.global.userToken1ExtraPerm = ['Authorization', `bearer ${userToken1ExtraPerm.token}`];
 
         this.global.adminAuth2 = ['Authorization', `bearer ${adminToken2.token}`];

--- a/lib/secret-service/src/test/tokens.js
+++ b/lib/secret-service/src/test/tokens.js
@@ -1,4 +1,5 @@
 const permissions = require('../constant/permission');
+const mongoose = require('mongoose');
 
 module.exports = {
 
@@ -23,6 +24,18 @@ module.exports = {
             permissions: [
                 'tenant.all',
             ],
+        },
+    },
+
+    userAuth1SecondUser: {
+        token: 'userAuth1SecondUser',
+        value: {
+            sub: 'u22',
+            name: 'User22',
+            role: 'USER',
+            iat: 1337,
+            tenant: '5c507eb60838f1f976e5f2a4',
+            permissions: [],
         },
     },
 
@@ -86,6 +99,7 @@ module.exports = {
             name: 'User4',
             role: 'NOT_USER',
             iat: 1337,
+            tenant: mongoose.Types.ObjectId(),
         },
     },
 

--- a/services/iam/src/access-control/permissions.js
+++ b/services/iam/src/access-control/permissions.js
@@ -29,7 +29,6 @@ const PERMISSIONS = {
 
         'iam.token.introspect': 'iam.token.introspect',
 
-        'secrets.raw.read': 'secrets.raw.read',
         'secrets.secret.deleteAny': 'secrets.secret.deleteAny',
         'secrets.authClient.deleteAny': 'secrets.authClient.deleteAny',
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1382,6 +1382,16 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
+"@openintegrationhub/event-bus@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@openintegrationhub/event-bus/-/event-bus-1.0.2.tgz#19eac710498ce2d27fa0e67e94e3f5d680420373"
+  integrity sha512-HeehldbfJnDuU79hQm/S6t/Uzndb30EaK8YjG3dESWkp7ptbJ7z2V1ByRzbHkmRi9L+O+oM+aIQlWgTHwkW4qQ==
+  dependencies:
+    amqplib "0.5.2"
+    assert "1.4.1"
+    bunyan "1.8.12"
+    lodash "4.17.11"
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -12208,7 +12218,7 @@ lodash@4.17.11, lodash@4.x, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.13.1, lo
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
-lodash@^4.17.12, lodash@^4.17.14:
+lodash@4.17.15, lodash@^4.17.12, lodash@^4.17.14:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==


### PR DESCRIPTION
**What has changed?**

A secret can no be shared with colleagues (other tenant users). This should allows users to create shared secrets for flows, which can be triggered by any user of the same tenant.

---

[**Definition of Done**](https://github.com/openintegrationhub/openintegrationhub/blob/crudmonitoring/CONTRIBUTING.md#definition-of-done)
