### PR TITLE
deleted tokens must return 404

### DIFF
--- a/services/iam/src/routes/tokens.js
+++ b/services/iam/src/routes/tokens.js
@@ -160,11 +160,11 @@ router.get('/refresh', async (req, res, next) => {
 router.get('/:id', auth.isAdmin, async (req, res, next) => {
 
     try {
-        const doc = await TokenDAO.find({ _id: req.params.id });
+        const doc = await TokenDAO.findOne({ _id: req.params.id });
         if (!doc) {
             return res.sendStatus(404);
         } else {
-            return res.send(doc[0]);
+            return res.send(doc);
         }
 
     } catch (err) {

--- a/services/iam/test/integration.spec.js
+++ b/services/iam/test/integration.spec.js
@@ -898,6 +898,12 @@ describe('routes', () => {
                 .set('Accept', /application\/json/)
                 .expect(200);
 
+            /* Admin deletes the token */
+            await request.get(`/api/v1/tokens/${tokenResp.body[0]._id}`)
+                .set('Authorization', tokenAdmin)
+                .set('Accept', /application\/json/)
+                .expect(404);
+
             /* Service account fetch user data fails */
             await request.get('/api/v1/users/me')
                 .set('Authorization', `Bearer ${portTokenResponse.body.token}`)


### PR DESCRIPTION
**What has changed?**
Deleted tokens return a 404 error instead of an empty 200