### PR TITLE
updated data-hub k8s descriptor

### DIFF
--- a/services/data-hub/k8s/deployment.yaml
+++ b/services/data-hub/k8s/deployment.yaml
@@ -25,6 +25,11 @@ spec:
                 secretKeyRef:
                   name: data-hub
                   key: MONGODB_URI
+            - name: RABBITMQ_URI
+                valueFrom:
+                  secretKeyRef:
+                    name: data-hub
+                    key: RABBITMQ_URI
             - name: PORT
               value: '1234'
             - name: IAM_TOKEN


### PR DESCRIPTION
- added RABBITMQ_URI env var

---

[**Definition of Done**](https://github.com/openintegrationhub/openintegrationhub/blob/crudmonitoring/CONTRIBUTING.md#definition-of-done)
