### PR TITLE
Now uses user.isAdmin

### DIFF
--- a/services/flow-repository/app/api/controllers/flow.js
+++ b/services/flow-repository/app/api/controllers/flow.js
@@ -73,7 +73,7 @@ router.get('/', jsonParser, can(config.flowReadPermission), async (req, res) => 
 
   // filter[user]
   if (req.query.filter && req.query.filter.user !== undefined) {
-    if (!config.oihAdminRoles.includes(req.user.role)) {
+    if (!req.user.isAdmin) {
       return res.status(403).send({ errors: [{ message: 'Filtering by user is only available to admins', code: 403 }] });
     }
     filters.user = req.query.filter.user;

--- a/services/flow-repository/app/api/controllers/mongo.js
+++ b/services/flow-repository/app/api/controllers/mongo.js
@@ -28,7 +28,7 @@ const buildQuery = (user, permission, id) => {
   }
 
   // If the user is not an OIH admin, constrain query by flow ownership
-  if (!config.oihAdminRoles.includes(user.role)) {
+  if (!user.isAdmin) {
     const owners = [user.sub];
     if (user.tenant) owners.push(user.tenant);
     qry['owners.id'] = { $in: owners };

--- a/services/flow-repository/app/config/index.js
+++ b/services/flow-repository/app/config/index.js
@@ -3,7 +3,6 @@
 const general = {
   mongoUrl: process.env.MONGODB_URL || 'mongodb://localhost:27017/flowRepoDev',
   amqpUrl: process.env.QUEUE_URL || 'amqp://guest:guest@localhost:5672',
-  oihAdminRoles: ['ADMIN', 'SERVICE_ACCOUNT'],
   gdprEventName: 'iam.user.deleted',
 
   flowReadPermission: process.env.FLOW_READ_PERMISSION || 'flows.read',


### PR DESCRIPTION
**What has changed?**

Fixed a bug where Flow Repository still used outdated IAM syntax

---

[**Definition of Done**](https://github.com/openintegrationhub/openintegrationhub/blob/crudmonitoring/CONTRIBUTING.md#definition-of-done)
