### PR TITLE
Added typescript definitions to cfm module

### DIFF
--- a/lib/cfm/index.d.ts
+++ b/lib/cfm/index.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="node" />
+
+export class CFM {
+    public resolve(incoming: object, target: object): object;
+    public setRules(rules: object): void;
+    public setDefaultRules(rules: object): void;
+    public setGlobalRules(rules: object): void;
+    public addCustomRule(name: string, resolvers: string[]): void;
+    public addCustomResolver(name: string, resolver: Function): void
+}


### PR DESCRIPTION
**What has changed?**

CFM now has an index.d.ts file describing its typing for typescript users

---

[**Definition of Done**](https://github.com/openintegrationhub/openintegrationhub/blob/crudmonitoring/CONTRIBUTING.md#definition-of-done)
