### PR TITLE
Added resource limits. Default memory limit for flow containers: 64Mi

### DIFF
--- a/platform/redis.yaml
+++ b/platform/redis.yaml
@@ -18,10 +18,6 @@ spec:
       containers:
         - name: master
           image: redis
-          resources:
-            requests:
-              cpu: 0.2
-              memory: 512Mi
           ports:
             - containerPort: 6379
 ---

--- a/services/attachment-storage-service/k8s/deployment.yaml
+++ b/services/attachment-storage-service/k8s/deployment.yaml
@@ -34,6 +34,10 @@ spec:
                   key: IAM_TOKEN
             - name: LOG_LEVEL
               value: trace
+          resources:
+            limits:
+              cpu: 0.1
+              memory: 512Mi
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: IfNotPresent

--- a/services/component-orchestrator/config/default.json
+++ b/services/component-orchestrator/config/default.json
@@ -3,7 +3,7 @@
     "DEFAULT_CPU_LIMIT": "100m",
     "DEFAULT_MEM_LIMIT": "256Mi",
     "DEFAULT_CPU_REQUEST": "100m",
-    "DEFAULT_MEM_REQUEST": "256Mi",
+    "DEFAULT_MEM_REQUEST": "64Mi",
     "LISTEN_PORT": 1234,
     "NAMESPACE": "flows",
     "SECRETS_SERVICE_BASE_URL": "http://secret-service.oih-dev-ns.svc.cluster.local:3000/api/v1",

--- a/services/component-orchestrator/k8s/deployment.yaml
+++ b/services/component-orchestrator/k8s/deployment.yaml
@@ -47,6 +47,10 @@ spec:
                 http://guest:guest@rabbitmq-service.oih-dev-ns.svc.cluster.local:15672/
             - name: SELF_URL
               value: 'http://api-service.oih-dev-ns.svc.cluster.local'
+          resources:
+            limits:
+              cpu: 0.1
+              memory: 512Mi
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: IfNotPresent

--- a/services/component-repository/k8s/deployment.yaml
+++ b/services/component-repository/k8s/deployment.yaml
@@ -36,6 +36,10 @@ spec:
                   key: IAM_TOKEN
             - name: LOG_LEVEL
               value: trace
+          resources:
+            limits:
+              cpu: 0.1
+              memory: 512Mi
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: IfNotPresent

--- a/services/data-hub/k8s/deployment.yaml
+++ b/services/data-hub/k8s/deployment.yaml
@@ -39,6 +39,10 @@ spec:
                   key: IAM_TOKEN
             - name: LOG_LEVEL
               value: trace
+          resources:
+            limits:
+              cpu: 0.1
+              memory: 512Mi
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: IfNotPresent

--- a/services/logging-service/k8s/deployment.yaml
+++ b/services/logging-service/k8s/deployment.yaml
@@ -31,6 +31,10 @@ spec:
               value: '1234'
             - name: LOG_LEVEL
               value: trace
+          resources:
+            limits:
+              cpu: 0.1
+              memory: 512Mi
           volumeMounts:
             - name: credentials
               mountPath: '/usr/lib/app/credentials'

--- a/services/scheduler/k8s/deployment.yaml
+++ b/services/scheduler/k8s/deployment.yaml
@@ -30,6 +30,10 @@ spec:
                 amqp://guest:guest@rabbitmq-service.oih-dev-ns.svc.cluster.local
             - name: LISTEN_PORT
               value: '1234'
+          resources:
+            limits:
+              cpu: 0.1
+              memory: 512Mi
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: IfNotPresent

--- a/services/snapshots-service/k8s/deployment.yaml
+++ b/services/snapshots-service/k8s/deployment.yaml
@@ -39,6 +39,10 @@ spec:
               value: '1234'
             - name: LOG_LEVEL
               value: trace
+          resources:
+            limits:
+              cpu: 0.1
+              memory: 512Mi
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: IfNotPresent

--- a/services/webhooks/k8s/deployment.yaml
+++ b/services/webhooks/k8s/deployment.yaml
@@ -32,6 +32,10 @@ spec:
               value: '1234'
             - name: LOG_LEVEL
               value: trace
+          resources:
+            limits:
+              cpu: 0.1
+              memory: 512Mi
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
**What has changed?**

- see PR

---

[**Definition of Done**](https://github.com/openintegrationhub/openintegrationhub/blob/crudmonitoring/CONTRIBUTING.md#definition-of-done)
