### PR TITLE
Improved documentation for env variables

### DIFF
--- a/services/component-repository/README.md
+++ b/services/component-repository/README.md
@@ -54,3 +54,4 @@ Kubernetes descriptors can be found in the [k8s](./k8s) directory.
 | MONGODB_URI | MongoDB connection string. |
 | PORT | Port for HTTP interface. |
 | RABBITMQ_URI | RabbitMQ connection string. |
+| INTROSPECT_ENDPOINT_BASIC | URL of the introspection endpoint of the IAM deployment. |

--- a/services/component-repository/k8s/deployment.yaml
+++ b/services/component-repository/k8s/deployment.yaml
@@ -36,6 +36,10 @@ spec:
                   key: IAM_TOKEN
             - name: LOG_LEVEL
               value: trace
+            - name: "INTROSPECT_ENDPOINT_BASIC"
+              value: "http://iam.openintegrationhub.com/api/v1/tokens/introspect"
+            - name:  CORS_ORIGIN_WHITELIST
+              value: 'openintegrationhub.com,http://web-ui.openintegrationhub.com'
           resources:
             limits:
               cpu: 0.1


### PR DESCRIPTION
**What has changed?**

- Env Variables used by Component Repository are now explicitly noted in its yaml, rather than relying on defaults

---

[**Definition of Done**](https://github.com/openintegrationhub/openintegrationhub/blob/crudmonitoring/CONTRIBUTING.md#definition-of-done)
