### PR TITLE
Fix https://github.com/openintegrationhub/openintegrationhub/issues/993

### DIFF
--- a/lib/component-orchestrator/src/ComponentOrchestrator.js
+++ b/lib/component-orchestrator/src/ComponentOrchestrator.js
@@ -330,6 +330,7 @@ class ComponentOrchestrator {
         const record = {
             taskId: flow._id.toString(),
             execId: uuid().replace(/-/g, ''),
+            userId: 'DOES NOT MATTER', // Required by Sailor
             stepId,
             authToken,
             orchestratorToken,


### PR DESCRIPTION
A recent component-orchestrator update stopped sending `UserId` in messages to flow nodes, which breaks compatibility with existing sailor components. This PR adds that field back in.