### PR TITLE
Fix issue where failures during OAuth flows would not be presented to…

### DIFF
--- a/lib/secret-service/src/auth-flow-manager/index.js
+++ b/lib/secret-service/src/auth-flow-manager/index.js
@@ -75,7 +75,12 @@ function requestHelper(url, form) {
                 reject(err);
             } else {
                 try {
-                    resolve(JSON.parse(body));
+                    const obj = JSON.parse(body);
+                    if (res.statusCode === 200) {
+                        resolve(obj);
+                    } else {
+                        reject(obj);
+                    }
                 } catch (e) {
                     log.error({ __errName: 'requestHelper failed to parse response', body, exception: e });
                     reject(e);
@@ -133,19 +138,19 @@ module.exports = {
     }) {
         // create authorization request url
         switch (authClient.type) {
-            case OA2_AUTHORIZATION_CODE:
-                return authClient.endpoints.auth
-                    .replace('{{scope}}', encodeURI(
-                        (authClient.predefinedScope ? `${authClient.predefinedScope} ` : '') + scope,
-                    ))
-                    .replace('{{state}}', encodeURI(state))
-                    .replace('{{redirectUri}}', encodeURI(authClient.redirectUri))
-                    .replace('{{clientId}}', encodeURI(authClient.clientId));
-            case OA1_THREE_LEGGED:
-                return await oauthGetAuthorize({
-                    authClient, flow,
-                });
-            default:
+        case OA2_AUTHORIZATION_CODE:
+            return authClient.endpoints.auth
+                .replace('{{scope}}', encodeURI(
+                    (authClient.predefinedScope ? `${authClient.predefinedScope} ` : '') + scope,
+                ))
+                .replace('{{state}}', encodeURI(state))
+                .replace('{{redirectUri}}', encodeURI(authClient.redirectUri))
+                .replace('{{clientId}}', encodeURI(authClient.clientId));
+        case OA1_THREE_LEGGED:
+            return await oauthGetAuthorize({
+                authClient, flow,
+            });
+        default:
         }
     },
     async continue({
@@ -156,18 +161,18 @@ module.exports = {
         } = authClient;
 
         switch (authClient.type) {
-            case OA2_AUTHORIZATION_CODE:
-                return await exchangeRequest(authClient.endpoints.token, {
-                    code,
-                    clientId,
-                    clientSecret,
-                    redirectUri,
-                });
-            case OA1_THREE_LEGGED:
-                return await oauthGetAccess({
-                    authClient, flow, queryObject,
-                });
-            default:
+        case OA2_AUTHORIZATION_CODE:
+            return await exchangeRequest(authClient.endpoints.token, {
+                code,
+                clientId,
+                clientSecret,
+                redirectUri,
+            });
+        case OA1_THREE_LEGGED:
+            return await oauthGetAccess({
+                authClient, flow, queryObject,
+            });
+        default:
         }
     },
     async refresh(authClient, secret) {
@@ -175,14 +180,14 @@ module.exports = {
         const { refreshToken } = secret.value;
 
         switch (authClient.type) {
-            case OA2_AUTHORIZATION_CODE:
-                return await refreshRequest(authClient.endpoints.token, {
-                    clientId,
-                    clientSecret,
-                    refreshToken,
-                });
+        case OA2_AUTHORIZATION_CODE:
+            return await refreshRequest(authClient.endpoints.token, {
+                clientId,
+                clientSecret,
+                refreshToken,
+            });
 
-            default:
+        default:
         }
     },
 

--- a/lib/secret-service/src/route/callback/index.js
+++ b/lib/secret-service/src/route/callback/index.js
@@ -30,7 +30,7 @@ router.get('/', async (req, res, next) => {
         log.error(err);
         next({
             status: 400,
-            message: err.message,
+            message: err.message || err,
         });
     }
 });


### PR DESCRIPTION
Fix issue where failures during OAuth flows would not be presented to the receiver. Instead, it would try to save the error response as an Auth Secret, which would fail validation, obscuring the real error message.