### PR TITLE
Now automatically sets active flag on global components

### DIFF
--- a/lib/component-repository/spec/integration/routes/components/global.spec.js
+++ b/lib/component-repository/spec/integration/routes/components/global.spec.js
@@ -6,7 +6,7 @@ const EventBusMock = require('../../EventBusMock');
 const { can, hasOneOf } = require('@openintegrationhub/iam-utils');
 
 
-describe('GET /components/global/:id/...', () => {
+describe('POST /components/global/:id/...', () => {
     let server;
 
     beforeEach(async () => {
@@ -91,7 +91,7 @@ describe('GET /components/global/:id/...', () => {
 
 
 let component;
-describe('GET /components/global/:id/...', () => {
+describe('POST /components/global/:id/...', () => {
     let server;
 
     beforeEach(async () => {
@@ -166,6 +166,8 @@ describe('GET /components/global/:id/...', () => {
         expect(statusCode).to.equal(200);
 
         expect(body).to.deep.equal({ message: 'Component started', code: 200 });
+        const updatedComponent = await Component.findOne({ _id: component.id }).lean();
+        expect(updatedComponent.active).to.be.true;
     });
 
     it('should stop a global component by ID', async () => {
@@ -174,6 +176,8 @@ describe('GET /components/global/:id/...', () => {
         expect(statusCode).to.equal(200);
 
         expect(body).to.deep.equal({ message: 'Component stopped', code: 200 });
+        const updatedComponent = await Component.findOne({ _id: component.id }).lean();
+        expect(updatedComponent.active).to.be.false;
     });
 
     it('should not start a normal component by ID', async () => {

--- a/lib/component-repository/src/routes/components/GlobalStart.js
+++ b/lib/component-repository/src/routes/components/GlobalStart.js
@@ -34,5 +34,8 @@ module.exports = async function (req, res) {
     } catch (err) {
       req.logger.error(err);
     }
+
+    await Component.updateOne({ '_id': componentId }, { $set: { active: true } }, { new: true })
+
     return res.status(200).send({ message: 'Component started', code: 200 });
 };

--- a/lib/component-repository/src/routes/components/GlobalStop.js
+++ b/lib/component-repository/src/routes/components/GlobalStop.js
@@ -35,5 +35,7 @@ module.exports = async function (req, res) {
       req.logger.error(err);
     }
 
+    await Component.updateOne({ '_id': componentId }, { $set: { active: false } })
+
     return res.status(200).send({ message: 'Component stopped', code: 200 });
 };


### PR DESCRIPTION
**What has changed?**

- Now automatically sets active flag upon starting or stopping global components

---

[**Definition of Done**](https://github.com/openintegrationhub/openintegrationhub/blob/crudmonitoring/CONTRIBUTING.md#definition-of-done)
