### PR TITLE
Add component caching to the Component Orchestrator

### DIFF
--- a/lib/component-orchestrator/src/ComponentOrchestrator.js
+++ b/lib/component-orchestrator/src/ComponentOrchestrator.js
@@ -269,13 +269,15 @@ class ComponentOrchestrator {
     async _handleMessage(message) {
         try {
             const { orchestratorToken } = message.properties.headers;
-            const { stepId, flowId } = jwt.verify(orchestratorToken, SECRET);
+            const { stepId, flowId, apiKey } = jwt.verify(orchestratorToken, SECRET);
 
             const flow = await this._flowsDao.findById(flowId);
 
-            const { token } = await this._tokensDao.getTokenByFlowId({
+            const token = apiKey;
+
+            /*const { token } = await this._tokensDao.getTokenByFlowId({
                 flowId: flow._id,
-            });
+            });*/
 
             const nextSteps = flow.getNextSteps(stepId);
 


### PR DESCRIPTION
As it stands, a component orchestrator handling a ton of traffic through its `_handleMessage` function will DoS the Component Repository, IAM Service, and Snapshot service when performing its various work. This adds some rudimentary caching to the ComponentDAO to prevent DoS'ing the Component Repository, and keeps us from having to pull the flow-specific token from IAM because it's already embedded in the `orchestratorToken`.

* Add component caching to the Component Orchestrator
* Instead of asking the token DAO for the flow-specific token, just use the flow token already embedded in the orchestrator token