### PR TITLE
fix oversight in secret-service manifest

### DIFF
--- a/services/secret-service/k8s/deployment.yaml
+++ b/services/secret-service/k8s/deployment.yaml
@@ -31,8 +31,8 @@ spec:
             - name: CRYPTO_KEY
               valueFrom:
                 secretKeyRef:
-                  name: crypto_key
-                  key: secret-service
+                  name: secret-service
+                  key: crypto_key
             # - name: IAM_OIDC_SERVICE_CLIENT_ID
             #   value: 8ce00058-5f75-435f-9026-ad952480e15a
             # - name: IAM_OIDC_SERVICE_CLIENT_SECRET


### PR DESCRIPTION
**What has changed?**

- Fix what looks like an oversight in the source manifests for `secret-service`

**Does a specific change require especially careful review?**

Was ist really an oversight or only a coincidence that the naming scheme should have been inverted just on this secret key?
 
- Change X
  - It might have been broken as is
  - `./service/secret-service/k8s/deployment.yaml`

---

[**Definition of Done**](https://github.com/openintegrationhub/openintegrationhub/blob/crudmonitoring/CONTRIBUTING.md#definition-of-done)

- [x] reviewed by competent authority and confirmed it was an oversight &mdash; merged
