### PR TITLE
fix typo

### DIFF
--- a/minikube/4-Services/secret-service/k8s/deployment.yaml
+++ b/minikube/4-Services/secret-service/k8s/deployment.yaml
@@ -51,7 +51,7 @@ spec:
               value: "3000"
             - name: API_BASE
               value: "/api/v1"
-            - name: LOGGING_LEVEL
+            - name: LOG_LEVEL
               value: "error"
             - name: TTL_AUTHFLOW
               value: "2m"


### PR DESCRIPTION
**What has changed?**

- LOGGING_LEVEL -> LOG_LEVEL for secret-service in minikube

**Does a specific change require especially careful review?**

Check: https://github.com/openintegrationhub/openintegrationhub/search?l=JavaScript&q=LOGGING_LEVEL &mdash; only `app-directory` seems to use `LOGGING_LEVEL` but I might apply bad assumptions.
 
- Change X
  - Dead code?

---

[**Definition of Done**](https://github.com/openintegrationhub/openintegrationhub/blob/crudmonitoring/CONTRIBUTING.md#definition-of-done)

- [ ] Reviewed &rarr; accepted
- [ ] Reviewer decides if other hits of `LOGGING_LEVEL` are also dead code and acts upon it, see filter: https://github.com/openintegrationhub/openintegrationhub/search?l=YAML&q=LOGGING_LEVEL (found in: `meta-data-repository`, other `secret-services`, `dokcer-compose`, etc.)