### PR TITLE
typo: fix schema violating yaml

### DIFF
--- a/dev-tools/minikube/4-Services/scheduler/sourceDeploy.yaml
+++ b/dev-tools/minikube/4-Services/scheduler/sourceDeploy.yaml
@@ -42,7 +42,7 @@ spec:
               value: debug
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
-           volumeMounts:
+          volumeMounts:
             - name: code
               mountPath: /usr/src/app
               subPath: services/scheduler


### PR DESCRIPTION
Tiny oversight that globally break my analysis tools (`kustomize cfg tree .`)