### PR TITLE
fix: oversight schmea violating yaml

### DIFF
--- a/dev-tools/minikube/4-Services/web-ui/sourceDeploy.yaml
+++ b/dev-tools/minikube/4-Services/web-ui/sourceDeploy.yaml
@@ -40,9 +40,9 @@ spec:
           - name: ENDPOINT_APP_DIRECTORY
             value: 'http://app-directory.localoih.com/api/v1'
           - name: NODE_ENV
-              value: development
+            value: development
           - name: LOG_LEVEL
-              value: debug
+            value: debug
           ports:
           - containerPort: 3000
           volumeMounts:


### PR DESCRIPTION
Tiny oversight that globally break my analysis tools (`kustomize cfg tree .`)

(sorry for two separate PRs, this is _quick-fix fallout_ through the github web interface while working on my main feature branch)