### PR TITLE
cleanup/fix: extensions/v1beta1 -> apps/v1

### DIFF
--- a/services/app-directory/k8s/deployment/deployment.yaml
+++ b/services/app-directory/k8s/deployment/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app-directory

--- a/services/iam/k8s/deployment/deployment.yaml
+++ b/services/iam/k8s/deployment/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: iam

--- a/services/meta-data-repository/k8s/deployment/deployment.yaml
+++ b/services/meta-data-repository/k8s/deployment/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: meta-data-repository

--- a/services/reports-analytics/k8s/deployment/deployment.yaml
+++ b/services/reports-analytics/k8s/deployment/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: reports-analytics

--- a/services/secret-service/k8s/deployment/deployment.yaml
+++ b/services/secret-service/k8s/deployment/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: secret-service

--- a/services/web-ui/k8s/deployment/deployment.yaml
+++ b/services/web-ui/k8s/deployment/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: web-ui


### PR DESCRIPTION
&rarr; `rg -Nl extensions/v1beta1 services | xargs -n1 -I{} sed -i 's|extensions/v1beta1|apps/v1|g' {}`
&rarr; inspired by the diffs in #1054 

@weberjm A no-brainer which avoids API incompatibility surprises downstream. The current configuration does not use any feature exclusive to the beta version of the api &mdash; I'm not even sure if anything has been deprecated since the beta version.