### PR TITLE
cleanup: Remove superflue sec context

### DIFF
--- a/services/attachment-storage-service/k8s/deployment/deployment.yaml
+++ b/services/attachment-storage-service/k8s/deployment/deployment.yaml
@@ -50,8 +50,6 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         imagePullPolicy: IfNotPresent
-        securityContext:
-          privileged: false
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/services/component-orchestrator/k8s/deployment/deployment.yaml
+++ b/services/component-orchestrator/k8s/deployment/deployment.yaml
@@ -51,8 +51,6 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         imagePullPolicy: IfNotPresent
-        securityContext:
-          privileged: false
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/services/component-repository/k8s/deployment/deployment.yaml
+++ b/services/component-repository/k8s/deployment/deployment.yaml
@@ -50,8 +50,6 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         imagePullPolicy: IfNotPresent
-        securityContext:
-          privileged: false
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/services/data-hub/k8s/deployment/deployment.yaml
+++ b/services/data-hub/k8s/deployment/deployment.yaml
@@ -55,8 +55,6 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         imagePullPolicy: IfNotPresent
-        securityContext:
-          privileged: false
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/services/logging-service/k8s/deployment/deployment.yaml
+++ b/services/logging-service/k8s/deployment/deployment.yaml
@@ -48,8 +48,6 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         imagePullPolicy: IfNotPresent
-        securityContext:
-          privileged: false
       volumes:
       - name: credentials
         secret:

--- a/services/scheduler/k8s/deployment/deployment.yaml
+++ b/services/scheduler/k8s/deployment/deployment.yaml
@@ -45,8 +45,6 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         imagePullPolicy: IfNotPresent
-        securityContext:
-          privileged: false
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/services/snapshots-service/k8s/deployment/deployment.yaml
+++ b/services/snapshots-service/k8s/deployment/deployment.yaml
@@ -55,8 +55,6 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         imagePullPolicy: IfNotPresent
-        securityContext:
-          privileged: false
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/services/webhooks/k8s/deployment/deployment.yaml
+++ b/services/webhooks/k8s/deployment/deployment.yaml
@@ -46,8 +46,6 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         imagePullPolicy: IfNotPresent
-        securityContext:
-          privileged: false
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
```yaml
        securityContext:
          privileged: false
```

is a [k8s default](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#securitycontext-v1-core), so remove it to avoid confusion (as if it was set to false on purpose):

> Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. **Defaults to false.**