### PR TITLE
cleanup: Remove superflue terminationmessage

### DIFF
--- a/services/attachment-storage-service/k8s/deployment/deployment.yaml
+++ b/services/attachment-storage-service/k8s/deployment/deployment.yaml
@@ -47,8 +47,6 @@ spec:
           httpGet:
             port: 3002
             path: /healthcheck
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: false

--- a/services/component-orchestrator/k8s/deployment/deployment.yaml
+++ b/services/component-orchestrator/k8s/deployment/deployment.yaml
@@ -48,8 +48,6 @@ spec:
           httpGet:
             port: 1234
             path: /healthcheck
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: false

--- a/services/component-repository/k8s/deployment/deployment.yaml
+++ b/services/component-repository/k8s/deployment/deployment.yaml
@@ -47,8 +47,6 @@ spec:
           httpGet:
             port: 1234
             path: /healthcheck
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: false

--- a/services/data-hub/k8s/deployment/deployment.yaml
+++ b/services/data-hub/k8s/deployment/deployment.yaml
@@ -52,8 +52,6 @@ spec:
           httpGet:
             port: 1234
             path: /healthcheck
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: false

--- a/services/logging-service/k8s/deployment/deployment.yaml
+++ b/services/logging-service/k8s/deployment/deployment.yaml
@@ -45,8 +45,6 @@ spec:
           httpGet:
             port: 1234
             path: /healthcheck
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: false

--- a/services/scheduler/k8s/deployment/deployment.yaml
+++ b/services/scheduler/k8s/deployment/deployment.yaml
@@ -42,8 +42,6 @@ spec:
           httpGet:
             port: 1234
             path: /healthcheck
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: false

--- a/services/snapshots-service/k8s/deployment/deployment.yaml
+++ b/services/snapshots-service/k8s/deployment/deployment.yaml
@@ -52,8 +52,6 @@ spec:
           httpGet:
             port: 1234
             path: /healthcheck
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: false

--- a/services/webhooks/k8s/deployment/deployment.yaml
+++ b/services/webhooks/k8s/deployment/deployment.yaml
@@ -43,8 +43,6 @@ spec:
           httpGet:
             port: 1234
             path: /healthcheck
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: false


### PR DESCRIPTION
```yaml
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
```

is a [k8s default](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#container-v1-core), so remove it to avoid confusion (as if it was set on purpose):

-- | --
-- | --
terminationMessagePathstring | Optional:  Path at which the file to which the container's termination message  will be written is mounted into the container's filesystem. Message  written is intended to be brief final status, such as an assertion  failure message. Will be truncated by the node if greater than 4096  bytes. The total message length across all containers will be limited to  12kb. **Defaults to /dev/termination-log**. Cannot be updated.
terminationMessagePolicystring | Indicate  how the termination message should be populated. File will use the  contents of terminationMessagePath to populate the container status  message on both success and failure. FallbackToLogsOnError will use the  last chunk of container log output if the termination message file is  empty and the container exited with an error. The log output is limited  to 2048 bytes or 80 lines, whichever is smaller. **Defaults to File**.  Cannot be updated.

