### PR TITLE
cleanup: Remove superflue terminationgraceperiod

### DIFF
--- a/services/attachment-storage-service/k8s/deployment/deployment.yaml
+++ b/services/attachment-storage-service/k8s/deployment/deployment.yaml
@@ -17,7 +17,6 @@ spec:
         app: attachment-storage-service
     spec:
       restartPolicy: Always
-      terminationGracePeriodSeconds: 30
       containers:
       - name: attachment-storage-service
         image: "openintegrationhub/attachment-storage-service:latest"

--- a/services/component-orchestrator/k8s/deployment/deployment.yaml
+++ b/services/component-orchestrator/k8s/deployment/deployment.yaml
@@ -17,7 +17,6 @@ spec:
         app: component-orchestrator
     spec:
       restartPolicy: Always
-      terminationGracePeriodSeconds: 30
       serviceAccountName: component-orchestrator-account
       containers:
       - name: component-orchestrator

--- a/services/component-repository/k8s/deployment/deployment.yaml
+++ b/services/component-repository/k8s/deployment/deployment.yaml
@@ -17,7 +17,6 @@ spec:
         app: component-repository
     spec:
       restartPolicy: Always
-      terminationGracePeriodSeconds: 30
       containers:
       - name: component-repository
         image: "openintegrationhub/component-repository:latest"

--- a/services/data-hub/k8s/deployment/deployment.yaml
+++ b/services/data-hub/k8s/deployment/deployment.yaml
@@ -17,7 +17,6 @@ spec:
         app: data-hub
     spec:
       restartPolicy: Always
-      terminationGracePeriodSeconds: 30
       containers:
       - name: data-hub
         image: "openintegrationhub/data-hub:latest"

--- a/services/logging-service/k8s/deployment/deployment.yaml
+++ b/services/logging-service/k8s/deployment/deployment.yaml
@@ -17,7 +17,6 @@ spec:
         app: logging-service
     spec:
       restartPolicy: Always
-      terminationGracePeriodSeconds: 30
       containers:
       - name: logging-service
         image: "openintegrationhub/logging-service:latest"

--- a/services/scheduler/k8s/deployment/deployment.yaml
+++ b/services/scheduler/k8s/deployment/deployment.yaml
@@ -17,7 +17,6 @@ spec:
         app: scheduler
     spec:
       restartPolicy: Always
-      terminationGracePeriodSeconds: 30
       containers:
       - name: scheduler
         image: "openintegrationhub/scheduler:latest"

--- a/services/snapshots-service/k8s/deployment/deployment.yaml
+++ b/services/snapshots-service/k8s/deployment/deployment.yaml
@@ -17,7 +17,6 @@ spec:
         app: snapshots-service
     spec:
       restartPolicy: Always
-      terminationGracePeriodSeconds: 30
       containers:
       - name: snapshots-service
         image: "openintegrationhub/snapshots-service:latest"

--- a/services/webhooks/k8s/deployment/deployment.yaml
+++ b/services/webhooks/k8s/deployment/deployment.yaml
@@ -17,7 +17,6 @@ spec:
         app: webhooks
     spec:
       restartPolicy: Always
-      terminationGracePeriodSeconds: 30
       serviceAccountName: component-orchestrator-account
       containers:
       - name: webhooks


### PR DESCRIPTION
```yaml
      terminationGracePeriodSeconds: 30
```

is a [k8s default](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#pod-v1-core), so remove it to avoid confusion (as if it was set to 30 on purpose):

-- | --
-- | --
terminationGracePeriodSecondsinteger | Optional  duration in seconds the pod needs to terminate gracefully. May be  decreased in delete request. Value must be non-negative integer. The  value zero indicates delete immediately. If this value is nil, the  default grace period will be used instead. The grace period is the  duration in seconds after the processes running in the pod are sent a  termination signal and the time when the processes are forcibly halted  with a kill signal. Set this value longer than the expected cleanup time  for your process. **Defaults to 30 seconds.**