### PR TITLE
Add k7e handle

### DIFF
--- a/platform/Kustomization
+++ b/platform/Kustomization
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespaces.yaml
+  - ./grafana.yaml
+  - ./influxdb.yaml
+  - ./ingress.yaml
+  - ./mongodb.yaml
+  - ./rabbitmq.yaml
+  - ./redis.yaml
+

--- a/services/app-directory/k8s/config/Kustomization
+++ b/services/app-directory/k8s/config/Kustomization
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml

--- a/services/app-directory/k8s/deployment/Kustomization
+++ b/services/app-directory/k8s/deployment/Kustomization
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./deployment.yaml
+  - ./service.yaml

--- a/services/attachment-storage-service/k8s/config/Kustomization
+++ b/services/attachment-storage-service/k8s/config/Kustomization
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml

--- a/services/attachment-storage-service/k8s/deployment/Kustomization
+++ b/services/attachment-storage-service/k8s/deployment/Kustomization
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./deployment.yaml
+  - ./service.yaml

--- a/services/audit-log/k8s/config/Kustomization
+++ b/services/audit-log/k8s/config/Kustomization
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml

--- a/services/audit-log/k8s/deployment/Kustomization
+++ b/services/audit-log/k8s/deployment/Kustomization
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./deployment.yaml
+  - ./service.yaml

--- a/services/component-orchestrator/k8s/config/Kustomization
+++ b/services/component-orchestrator/k8s/config/Kustomization
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml

--- a/services/component-orchestrator/k8s/deployment/Kustomization
+++ b/services/component-orchestrator/k8s/deployment/Kustomization
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./deployment.yaml
+  - ./service.yaml
+  - ./service-account.yaml

--- a/services/component-repository/k8s/config/Kustomization
+++ b/services/component-repository/k8s/config/Kustomization
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml

--- a/services/component-repository/k8s/deployment/Kustomization
+++ b/services/component-repository/k8s/deployment/Kustomization
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./deployment.yaml
+  - ./service.yaml

--- a/services/data-hub/k8s/config/Kustomization
+++ b/services/data-hub/k8s/config/Kustomization
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml

--- a/services/data-hub/k8s/deployment/Kustomization
+++ b/services/data-hub/k8s/deployment/Kustomization
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./deployment.yaml
+  - ./service.yaml

--- a/services/dispatcher-service/k8s/config/Kustomization
+++ b/services/dispatcher-service/k8s/config/Kustomization
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml

--- a/services/dispatcher-service/k8s/deployment/Kustomization
+++ b/services/dispatcher-service/k8s/deployment/Kustomization
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./deployment.yaml
+  - ./service.yaml

--- a/services/flow-repository/k8s/config/Kustomization
+++ b/services/flow-repository/k8s/config/Kustomization
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml

--- a/services/flow-repository/k8s/deployment/Kustomization
+++ b/services/flow-repository/k8s/deployment/Kustomization
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./deployment.yaml
+  - ./service.yaml

--- a/services/iam/k8s/config/Kustomization
+++ b/services/iam/k8s/config/Kustomization
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml

--- a/services/iam/k8s/deployment/Kustomization
+++ b/services/iam/k8s/deployment/Kustomization
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./deployment.yaml
+  - ./service.yaml

--- a/services/ils/k8s/deployment/Kustomization
+++ b/services/ils/k8s/deployment/Kustomization
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./deployment.yaml
+  - ./service.yaml

--- a/services/logging-service/k8s/config/Kustomization
+++ b/services/logging-service/k8s/config/Kustomization
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml

--- a/services/logging-service/k8s/deployment/Kustomization
+++ b/services/logging-service/k8s/deployment/Kustomization
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./deployment.yaml
+  - ./service.yaml

--- a/services/meta-data-repository/k8s/config/Kustomization
+++ b/services/meta-data-repository/k8s/config/Kustomization
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml

--- a/services/meta-data-repository/k8s/deployment/Kustomization
+++ b/services/meta-data-repository/k8s/deployment/Kustomization
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./deployment.yaml
+  - ./service.yaml

--- a/services/reports-analytics/k8s/config/Kustomization
+++ b/services/reports-analytics/k8s/config/Kustomization
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml

--- a/services/reports-analytics/k8s/deployment/Kustomization
+++ b/services/reports-analytics/k8s/deployment/Kustomization
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./deployment.yaml
+  - ./service.yaml

--- a/services/scheduler/k8s/config/Kustomization
+++ b/services/scheduler/k8s/config/Kustomization
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml

--- a/services/scheduler/k8s/deployment/Kustomization
+++ b/services/scheduler/k8s/deployment/Kustomization
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./deployment.yaml

--- a/services/secret-service/k8s/config/Kustomization
+++ b/services/secret-service/k8s/config/Kustomization
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml

--- a/services/secret-service/k8s/deployment/Kustomization
+++ b/services/secret-service/k8s/deployment/Kustomization
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./deployment.yaml
+  - ./service.yaml

--- a/services/snapshots-service/k8s/config/Kustomization
+++ b/services/snapshots-service/k8s/config/Kustomization
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml

--- a/services/snapshots-service/k8s/deployment/Kustomization
+++ b/services/snapshots-service/k8s/deployment/Kustomization
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./deployment.yaml
+  - ./service.yaml

--- a/services/web-ui/k8s/config/Kustomization
+++ b/services/web-ui/k8s/config/Kustomization
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml

--- a/services/web-ui/k8s/deployment/Kustomization
+++ b/services/web-ui/k8s/deployment/Kustomization
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./deployment.yaml
+  - ./service.yaml

--- a/services/webhooks/k8s/config/Kustomization
+++ b/services/webhooks/k8s/config/Kustomization
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml

--- a/services/webhooks/k8s/deployment/Kustomization
+++ b/services/webhooks/k8s/deployment/Kustomization
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./deployment.yaml
+  - ./service.yaml


### PR DESCRIPTION
**What has changed?**

- add innocuous `Kustomization` manifests (& very low maintenance! &mdash; they only ever change should the folder structure change in the future which might involve one of my suggestions anyway :wink: )
- the current api does not change
- additionally, those resources can be consumed downstream as Kustomization urlpaths.
- as a _"not officially supported"_ feature, no documentation is required. `Kustomization` gitops power users are supposed to know what they re looking for, the mere existence of those files is in itself more than enough documentation.

***this is not possible otherwise, without forking the entire repo &mdash; or similar terrible hacks which involve copying files around manually***

```
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
resources:
  - github.com/openintegrationhub/openintegrationhub/services/app-directory/k8s/deployment?ref=master
  - github.com/openintegrationhub/openintegrationhub/services/app-directory/k8s/config?ref=master
  - [...]
```

\* you'd never use `?ref=master`, of course.

**Does a specific change require especially careful review?**

No specifically careful review required. This does not change current behaviour. Naming those files `Kustomization` instead of the alternative `kustomization.yaml`, they entirely evict normal `kubectl apply -R` commands.

---

[**Definition of Done**](https://github.com/openintegrationhub/openintegrationhub/blob/crudmonitoring/CONTRIBUTING.md#definition-of-done)
