### PR TITLE
Template Fixes

### DIFF
--- a/platform/ingress.yaml
+++ b/platform/ingress.yaml
@@ -26,6 +26,12 @@ spec:
       - backend:
           serviceName: flow-repository
           servicePort: 3001
+  - host: template-repository.openintegrationhub.com
+    http:
+      paths:
+      - backend:
+          serviceName: template-repository
+          servicePort: 3001
   - host: auditlog.openintegrationhub.com
     http:
       paths:

--- a/services/template-repository/README.md
+++ b/services/template-repository/README.md
@@ -8,7 +8,7 @@ The revolution in data synchronization — the Open Integration Hub enables simp
 
 Visit the official [Open Integration Hub homepage](https://www.openintegrationhub.org/)
 
-# Template Repository (working title / Codename Bragi)
+# Template Repository
 
 The Template Repository stores, retrieves and updates flow teamplates in the Open Integration Hub.
 

--- a/services/template-repository/app/api/swagger/swagger.json
+++ b/services/template-repository/app/api/swagger/swagger.json
@@ -106,7 +106,7 @@
                   "properties": {
                     "data": {
                       "type": "array",
-                      "items": { "$ref": "#/components/schemas/FlowTemplates" }
+                      "items": { "$ref": "#/components/schemas/FlowTemplate" }
                     },
                     "meta": { "$ref": "#/components/schemas/Meta" }
                   }

--- a/services/template-repository/app/server.js
+++ b/services/template-repository/app/server.js
@@ -41,6 +41,11 @@ class Server {
       credentials: true,
     };
 
+    this.app.use((req, res, next) => {
+      req.headers.origin = req.headers.origin || req.headers.host;
+      next();
+    });
+
     // Enables preflight OPTIONS requests
     this.app.options('/', cors());
 


### PR DESCRIPTION
- Updated deployment docs for Template Repo Ingress
- FIX: Typo in Swagger API docs
- FIX: Updated CORS settings did not work for Origin-less calls (from API Managers, etc). Now it does.
