### PR TITLE
Now emits event to stop flow upon failure

### DIFF
--- a/services/flow-repository/app/utils/handlers.js
+++ b/services/flow-repository/app/utils/handlers.js
@@ -1,6 +1,7 @@
 const mongoose = require('mongoose');
 const log = require('../config/logger');
 const config = require('../config/index');
+// const { publishQueue } = require('./eventBus');
 
 const storage = require(`../api/controllers/${config.storage}`); // eslint-disable-line
 
@@ -36,11 +37,14 @@ async function flowFailed(id) {
     return false;
   }
 
-  const response = await storage.stoppedFlow(id);
-  if (!response) {
+  const flow = await storage.stoppingFlow({ isAdmin: true }, id);
+
+  if (!flow) {
     log.error(`Flow with id ${id} could not be found.`);
+    return false;
   }
-  return true;
+
+  return flow;
 }
 
 async function cleanupOrphans() {

--- a/services/flow-repository/test/test.js
+++ b/services/flow-repository/test/test.js
@@ -872,10 +872,12 @@ describe('Flow Operations', () => {
     expect(savedFailedFlow.status).toEqual('starting');
 
     const response = await flowFailed(savedFailedFlow._id.toString());
-    expect(response).toEqual(true);
+    expect(response).toHaveProperty('name', 'SnazzyToWice');
+    expect(response).toHaveProperty('status', 'stopping');
+    expect(response).toHaveProperty('id');
 
     const flow = await Flow.findOne({ _id: savedFailedFlow._id.toString() }).lean();
-    expect(flow.status).toEqual('inactive');
+    expect(flow.status).toEqual('stopping');
 
     await Flow.deleteOne({ _id: savedFailedFlow._id.toString() });
   });


### PR DESCRIPTION
**What has changed?**

When receiving a `flow.failed` event, the Flow Repository will now notify the Component Orchestrator to stop the flow entirely.

---

[**Definition of Done**](https://github.com/openintegrationhub/openintegrationhub/blob/crudmonitoring/CONTRIBUTING.md#definition-of-done)
