### PR TITLE
Update Documentation to represent current API behavior

### DIFF
--- a/services/iam/README.md
+++ b/services/iam/README.md
@@ -164,7 +164,7 @@ POST: /login (see open api docs)
 
 POST /api/v1/tokens (see open api docs)
 
-_If you want to create a permanent token, pass the "tokenLifeSpan" of -1_
+_If you want to create a permanent token, pass an "expiresIn" value of -1_
 
 #### Introspect a token
 

--- a/services/iam/doc/openapi.json
+++ b/services/iam/doc/openapi.json
@@ -780,7 +780,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/Token"
+                "$ref": "#/components/schemas/TokenCreate"
               }
             }
           }
@@ -952,6 +952,46 @@
           "tokenLifeSpan": {
             "type": "string",
             "description": "indicates the lifespan of the token. Possible values are -1 for permanent token and a string expression describing a time span, e.g. 2m, 5h"
+          }
+        }
+      },
+      "TokenCreate": {
+        "type": "object",
+        "properties": {
+          "inquirer": {
+            "type": "string",
+            "description": "Id of user or a service running on behalf of the user. Who wants the token to be created.",
+            "required": true
+          },
+          "initiator": {
+            "type": "string",
+            "description": "user or a a service who initiated this token request. Who is requesting the token creation (must have the permission to create a token). Defaults to requester id."
+          },
+          "accountId": {
+            "type": "string",
+            "description": "Affected account the token is created for",
+            "required": true
+          },
+          "token": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "EPHEMERAL_SERVICE_ACCOUNT",
+              "PERSISTENT",
+              "SELF"
+            ]
+          },
+          "permissions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Permissions"
+            }
+          },
+          "expiresIn": {
+            "type": "string",
+            "description": "Sets the lifespan of the token. Possible values are -1 for permanent token and a string expression describing a time span, e.g. 2m, 5h"
           }
         }
       },


### PR DESCRIPTION
Implementing the changes requested in #1093. The IAM `/tokens` POST call accepts `expiresIn` as a parameter, not `tokenLifespan` when creating a new token.

- Updated Service Documentation to reflect correct terminology
- Updated Swagger Docs to provide different schema for Token when creating.

See additional comments on #1093 to decide if any application changes are needed, which may supersede or revert these changes.

---

[**Definition of Done**](https://github.com/openintegrationhub/openintegrationhub/blob/crudmonitoring/CONTRIBUTING.md#definition-of-done)
