### PR TITLE
Add services to path

### DIFF
--- a/.github/workflows/tagReleases.yml
+++ b/.github/workflows/tagReleases.yml
@@ -51,7 +51,7 @@ jobs:
         id: service-version
         uses: notiz-dev/github-action-json-property@release
         with:
-          path: ${{ format('{0}/{1}',matrix.service,'package.json') }}
+          path: ${{ format('{0}/{1}/{2}','services',matrix.service,'package.json') }}
           prop_path: 'version'
       - name: Log Service Version
         run: echo "${{ steps.service-version.outputs.prop }}"


### PR DESCRIPTION
working directory is not persisted across jobs, so the path returned to root of project
