### PR TITLE
GKE InfluxDB and Grafana Deployment

### DIFF
--- a/platform/grafana.yaml
+++ b/platform/grafana.yaml
@@ -42,9 +42,9 @@ spec:
           timeoutSeconds: 1
       volumes:
       - name: grafana-pdisk
-        gcePersistentDisk:
-          fsType: ext4
-          pdName: timeseries-grafana
+        persistentVolumeClaim:
+          claimName: grafana-pvc
+          readOnly: false
       securityContext:
         fsGroup: 472
         runAsUser: 472

--- a/platform/influxdb.yaml
+++ b/platform/influxdb.yaml
@@ -52,9 +52,9 @@ spec:
           timeoutSeconds: 1
       volumes:
       - name: influx-pdisk
-        gcePersistentDisk:
-          fsType: ext4
-          pdName: timeseries-influx
+        persistentVolumeClaim:
+          claimName: influx-pvc
+          readOnly: false
 ---
 apiVersion: v1
 kind: Service

--- a/platform/volumeClaim.yaml
+++ b/platform/volumeClaim.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grafana-pvc
+  namespace: oih-dev-ns
+  labels:
+    app: grafana
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: standard-rwo
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: influx-pvc
+  namespace: oih-dev-ns
+  labels:
+    app: influxdb
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: standard-rwo
+  resources:
+    requests:
+      storage: 1Gi


### PR DESCRIPTION


**What has changed?**

- Change 1 - Created a volumeClaim.yaml which is applied first and changed platform/influxdb.yaml and platform/grafana.yaml to use the respective PersistentVolumeClaim.

**Does a specific change require especially careful review?**

_Please describe in short which change needs careful review, why and which files are affected_

- Change 1
  - When I used the existing platform/influxdb.yaml and platform/grafana.yaml on GKE the volumes were not created/auto-provisioned and there was an undocumented command that needed to be run (see alternative below). I was using GKE Autopilot and the GCE persistent disk CSI driver was enabled by default.
  - I used the Grafana on Kubernetes directions https://grafana.com/docs/grafana/latest/installation/kubernetes/ and the GCE persistent disk CSI driver documentation https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/gce-pd-csi-driver to build the yaml file 
  - An alternative would be to document the gcloud command to create the persistent disk volumes instead of using the CSI driver to auto-provision the volumes. https://kubernetes.io/docs/concepts/storage/volumes/#gcepersistentdisk

**What is still open or a known issue?**

N/A

**Release Notes**

Added auto-provisioning of InfluxDB and Grafana PersistentVolumeClaim on GKE
