### PR TITLE
Updated all k8s yamls to no longer use beta apis

### DIFF
--- a/platform/ingress.yaml
+++ b/platform/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: oih-dev-ingress

--- a/services/app-directory/k8s/deployment/deployment.yaml
+++ b/services/app-directory/k8s/deployment/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app-directory

--- a/services/iam/k8s/deployment/deployment.yaml
+++ b/services/iam/k8s/deployment/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: iam

--- a/services/meta-data-repository/k8s/deployment/deployment.yaml
+++ b/services/meta-data-repository/k8s/deployment/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: meta-data-repository

--- a/services/reports-analytics/k8s/deployment/deployment.yaml
+++ b/services/reports-analytics/k8s/deployment/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: reports-analytics

--- a/services/secret-service/k8s/deployment/deployment.yaml
+++ b/services/secret-service/k8s/deployment/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: secret-service

--- a/services/web-ui/k8s/deployment/deployment.yaml
+++ b/services/web-ui/k8s/deployment/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: web-ui


### PR DESCRIPTION
**What has changed?**

Updated remaining k8s files that still referred to beta kubernetes apis to now use the current v1 api. Actual content of the files remained unchanged, there should be no change in behaviour.

**Release Notes**

All services should now be able to run on kubernetes clusters using kubernetes versions 1.16 and upwards without requiring further adjustment.
