### PR TITLE
Auth Client / Secret Improvements

### DIFF
--- a/services/secret-service/package.json
+++ b/services/secret-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secret-service",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Service to manage Keys/Tokens of external services",
   "main": "index.js",
   "author": "Basaas GmbH",

--- a/services/secret-service/src/auth-flow-manager/index.js
+++ b/services/secret-service/src/auth-flow-manager/index.js
@@ -103,6 +103,7 @@ async function requestHelper(url, form) {
         method: 'POST',
         headers: {
             'Content-Type': 'application/x-www-form-urlencoded',
+            Accept: 'application/json',
         },
         body: params,
     });
@@ -186,6 +187,7 @@ async function userinfoRequest(url, token) {
     const response = await fetch(url, {
         headers: {
             Authorization: `Bearer ${token}`,
+            Accept: 'application/json',
         },
     });
     return checkStatus(response).json();

--- a/services/secret-service/src/dao/secret.js
+++ b/services/secret-service/src/dao/secret.js
@@ -232,6 +232,18 @@ module.exports = {
         props);
     },
 
+    async findByAuthClient(
+        id,
+        authClientId,
+    ) {
+        return await Secret.full.find({
+            'value.authClientId': authClientId,
+            'owners.id': id,
+        },
+        'name type value.authClientId value.scope value.expires value.externalId owners currentError',
+        );
+    },
+
     async findByExternalId(externalId, authClientId) {
         return await Secret.full.findOne({
             'value.externalId': externalId,

--- a/services/secret-service/src/route/auth-clients/index.js
+++ b/services/secret-service/src/route/auth-clients/index.js
@@ -5,6 +5,7 @@ const base64url = require('base64url');
 const { restricted, common } = require('../../constant/permission');
 const AuthClientDAO = require('../../dao/auth-client');
 const AuthFlowDAO = require('../../dao/auth-flow');
+const { findByAuthClient } = require('../../dao/secret');
 const { userIsOwnerOfAuthClient } = require('../../middleware/auth');
 const { getKeyParameter } = require('../../middleware/key');
 const conf = require('../../conf');
@@ -184,6 +185,26 @@ class AuthClientRouter {
                 next({
                     err,
                     status: 500,
+                    message: err.message,
+                });
+            }
+        });
+
+        this.router.get('/:id/secrets', userIsOwnerOfAuthClient, async (req, res, next) => {
+            const authClient = req.obj;
+            try {
+                const secrets = findByAuthClient(
+                    req.user.sub,
+                    authClient._id,
+                );
+                res.send({
+                    data: secrets,
+                });
+            } catch (err) {
+                log.error(err);
+                next({
+                    err,
+                    status: 400,
                     message: err.message,
                 });
             }


### PR DESCRIPTION
Add lookup to provide list of secrets for a selected AuthClient.

Additionally, added Accept header to request JSON in replies from external OAuth endpoints. Our Auth Flow Manager only works correctly with JSON responses, and some services (like Github) require the Accept header in order to return JSON instead of plaintext. This should not break any services which support JSON responses; any other services would break on the flow anyway.