### PR TITLE
Auth client non owner

### DIFF
--- a/services/secret-service/package.json
+++ b/services/secret-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secret-service",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "Service to manage Keys/Tokens of external services",
   "main": "index.js",
   "author": "Basaas GmbH",

--- a/services/secret-service/src/route/auth-clients/index.js
+++ b/services/secret-service/src/route/auth-clients/index.js
@@ -190,8 +190,8 @@ class AuthClientRouter {
             }
         });
 
-        this.router.get('/:id/secrets', userIsOwnerOfAuthClient, async (req, res, next) => {
-            const authClient = req.obj;
+        this.router.get('/:id/secrets', /* userIsOwnerOfAuthClient, */ async (req, res, next) => {
+            const authClient = await AuthClientDAO.findOne({ _id: req.params.id });
             try {
                 const secrets = findByAuthClient(
                     req.user.sub,


### PR DESCRIPTION
When pulling secrets for an auth client, don't require user to be owner of the auth client (only of the secrets)