### PR TITLE
Bump versions

### DIFF
--- a/dev-tools/docker-compose/src/release/get-changed-packages.js
+++ b/dev-tools/docker-compose/src/release/get-changed-packages.js
@@ -1,0 +1,119 @@
+const { execSync } = require('child_process')
+const path = require('path')
+const fs = require('fs')
+const { checkTools } = require('../helper')
+
+function getAvailablePackages(type = 'services') {
+  const basePath = path.resolve(__dirname, `../../../../${type}`)
+  const paths = fs.readdirSync(basePath)
+  const results = []
+
+  for (const pkg of paths) {
+    const pkgPath = path.join(basePath, pkg)
+    const temp = JSON.parse(fs.readFileSync(`${pkgPath}/package.json`))
+    results.push({
+      name: pkg,
+      version: temp.version,
+      dependencies: temp.dependencies,
+      devDependencies: temp.devDependencies,
+      path: pkgPath,
+    })
+  }
+  return results
+}
+
+function getDependentPackages(available = {}, changedLib = '', type = '') {
+  const dependent = []
+  available[type].forEach((availablePkg) => {
+    if (available[type] === 'lib' && availablePkg.name === changedLib) return
+    const match = new RegExp(changedLib, 'i')
+
+    for (const dep of Object.keys(availablePkg.dependencies)) {
+      if (match.test(dep)) {
+        dependent.push(availablePkg.name)
+        return
+      }
+    }
+    for (const devDep of Object.keys(availablePkg.devDependencies)) {
+      if (match.test(devDep)) {
+        dependent.push(availablePkg.name)
+        return
+      }
+    }
+  })
+  return dependent
+}
+
+checkTools(['git'])
+
+async function run() {
+  const tag = process.argv[2]
+
+  const available = {
+    services: getAvailablePackages('services'),
+    lib: getAvailablePackages('lib'),
+  }
+
+  const ignored = {
+    services: ['logic-gateway'],
+    lib: ['secret-service'],
+  }
+
+  const changed = {
+    services: [],
+    lib: [],
+  }
+
+  const dependent = {
+    services: [],
+    lib: [],
+  }
+
+  const total = {
+    services: [],
+    lib: [],
+  }
+
+  if (!tag) throw new Error('Please provide a tag')
+
+  const result = execSync(
+    `git diff tags/${tag} --name-only | grep -E -i -w '^services|^lib' || true`
+  ).toString()
+
+  // create list of services / lib
+  const changes = result.split(/\n/g)
+
+  changes.forEach((fileName) => {
+    const pathSegments = fileName.split('/')
+    if (pathSegments[0] !== 'services' && pathSegments[0] !== 'lib') return
+    if (changed[pathSegments[0]].includes(pathSegments[1])) return
+    // if (ignored[pathSegments[0]].includes(pathSegments[1])) return
+    changed[pathSegments[0]].push(pathSegments[1])
+  })
+
+  // detect services that are dependent on changed libs
+  changed.lib.forEach((changedLib) => {
+    dependent.services = dependent.services.concat(
+      getDependentPackages(available, changedLib, 'services')
+    )
+  })
+
+  total.lib = [...new Set(changed.lib)].filter(
+    (lib) => !ignored.lib.includes(lib)
+  )
+
+  total.services = [
+    ...new Set(changed.services.concat(dependent.services)),
+  ].filter((service) => !ignored.services.includes(service))
+
+  console.log('lib', total.lib.length, total.lib)
+  console.log('services', total.services.length, total.services)
+}
+
+;(async () => {
+  try {
+    await run()
+  } catch (err) {
+    console.log(err)
+  }
+})()

--- a/dev-tools/docker-compose/src/release/get-changed-packages.js
+++ b/dev-tools/docker-compose/src/release/get-changed-packages.js
@@ -25,17 +25,12 @@ function getAvailablePackages(type = 'services') {
 function getDependentPackages(available = {}, changedLib = '', type = '') {
   const dependent = []
   available[type].forEach((availablePkg) => {
-    if (available[type] === 'lib' && availablePkg.name === changedLib) return
     const match = new RegExp(changedLib, 'i')
 
-    for (const dep of Object.keys(availablePkg.dependencies)) {
+    for (const dep of Object.keys(availablePkg.devDependencies).concat(
+      Object.keys(availablePkg.dependencies)
+    )) {
       if (match.test(dep)) {
-        dependent.push(availablePkg.name)
-        return
-      }
-    }
-    for (const devDep of Object.keys(availablePkg.devDependencies)) {
-      if (match.test(devDep)) {
         dependent.push(availablePkg.name)
         return
       }
@@ -51,7 +46,11 @@ function bumpMinor(available = {}, pkg = '', shouldPerformBump = false) {
 
     const newVersion = `${major}.${minor + 1}.${0}`
 
-    console.log(`${found.path}: ${found.version} -> ${newVersion}`)
+    console.log(
+      `${found.path.match(/(service|lib).+/)}: ${
+        found.version
+      } -> ${newVersion}`
+    )
     if (shouldPerformBump) {
       const temp = JSON.parse(fs.readFileSync(`${found.path}/package.json`))
       temp.version = newVersion

--- a/dev-tools/docker-compose/src/release/get-changed-packages.js
+++ b/dev-tools/docker-compose/src/release/get-changed-packages.js
@@ -54,7 +54,9 @@ function bumpMinor(available = {}, pkg = '', shouldPerformBump = false) {
     console.log(`${found.path}: ${found.version} -> ${newVersion}`)
     if (shouldPerformBump) {
       const temp = JSON.parse(fs.readFileSync(`${found.path}/package.json`))
-      temp.version = fs.writeFileSync(
+      temp.version = newVersion
+
+      fs.writeFileSync(
         `${found.path}/package.json`,
         JSON.stringify(temp, null, 2),
         'utf8'

--- a/dev-tools/docker-compose/src/release/get-changed-packages.js
+++ b/dev-tools/docker-compose/src/release/get-changed-packages.js
@@ -44,10 +44,29 @@ function getDependentPackages(available = {}, changedLib = '', type = '') {
   return dependent
 }
 
+function bumpMinor(available = {}, pkg = '') {
+  const found = available.find((p) => p.name === pkg)
+  if (found) {
+    const [major, minor, patch] = found.version
+      .split('.')
+      .map((v) => parseInt(v, 10))
+
+    console.log(major, minor, patch)
+    const temp = JSON.parse(fs.readFileSync(`${found.path}/package.json`))
+    temp.version = `${major}.${minor + 1}.${0}`
+    fs.writeFileSync(
+      `${found.path}/package.json`,
+      JSON.stringify(temp, null, 2),
+      'utf8'
+    )
+  }
+}
+
 checkTools(['git'])
 
 async function run() {
   const tag = process.argv[2]
+  const shouldBump = !!(process.argv[3] && process.argv[3] === 'bump')
 
   const available = {
     services: getAvailablePackages('services'),
@@ -108,6 +127,11 @@ async function run() {
 
   console.log('lib', total.lib.length, total.lib)
   console.log('services', total.services.length, total.services)
+
+  if (shouldBump) {
+    total.lib.forEach((lib) => bumpMinor(available.lib, lib))
+    total.services.forEach((service) => bumpMinor(available.services, service))
+  }
 }
 
 ;(async () => {

--- a/dev-tools/docker-compose/src/release/get-changed-packages.js
+++ b/dev-tools/docker-compose/src/release/get-changed-packages.js
@@ -47,7 +47,7 @@ function bumpMinor(available = {}, pkg = '', shouldPerformBump = false) {
     const newVersion = `${major}.${minor + 1}.${0}`
 
     console.log(
-      `${found.path.match(/(service|lib).+/)}: ${
+      `${found.path.match(/(service|lib).+/)[0]}: ${
         found.version
       } -> ${newVersion}`
     )

--- a/lib/component-orchestrator/package.json
+++ b/lib/component-orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openintegrationhub/component-orchestrator",
-  "version": "1.2.6",
+  "version": "1.3.0",
   "description": "Orchestrates cluster resources",
   "main": "src/index.js",
   "scripts": {

--- a/lib/component-repository/package.json
+++ b/lib/component-repository/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openintegrationhub/component-repository",
   "description": "Component repository",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "author": "Open Integration Hub",
   "engines": {
     "node": ">=12"

--- a/lib/ferryman/package.json
+++ b/lib/ferryman/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openintegrationhub/ferryman",
   "description": "Wrapper utility for Open Integration Hub connectors",
-  "version": "1.5.7",
+  "version": "1.6.0",
   "main": "run.js",
   "scripts": {
     "lint": "./node_modules/.bin/eslint lib mocha_spec lib runGlobal.js runService.js --fix",

--- a/lib/webhooks/package.json
+++ b/lib/webhooks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openintegrationhub/webhooks",
   "description": "webhooks",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "author": "Open Integration Hub",
   "engines": {
     "node": ">=12"

--- a/services/component-orchestrator/package.json
+++ b/services/component-orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-orchestrator",
-  "version": "1.2.11",
+  "version": "1.3.0",
   "description": "Resource coordinator",
   "main": "index.js",
   "scripts": {

--- a/services/component-repository/package.json
+++ b/services/component-repository/package.json
@@ -2,7 +2,7 @@
   "name": "component-repository",
   "description": "Component repository",
   "private": true,
-  "version": "1.2.2",
+  "version": "1.3.0",
   "author": "Open Integration Hub",
   "engines": {
     "node": ">=12"

--- a/services/data-hub/package.json
+++ b/services/data-hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-hub",
-  "version": "0.0.11",
+  "version": "0.1.0",
   "description": "Data hub",
   "main": "dist/index.js",
   "directories": {
@@ -50,7 +50,7 @@
     "@wice-devs/cfm": "1.0.8",
     "backend-commons-lib": "1.1.3",
     "bunyan": "1.8.15",
-    "faker":"5.5.3",
+    "faker": "5.5.3",
     "koa": "2.13.1",
     "koa-bodyparser": "4.3.0",
     "koa-bunyan-logger": "2.1.0",

--- a/services/data-hub/package.json
+++ b/services/data-hub/package.json
@@ -45,7 +45,7 @@
     "typescript": "3.8.3"
   },
   "dependencies": {
-    "@openintegrationhub/event-bus": "1.2.5",
+    "@openintegrationhub/event-bus": "*",
     "@openintegrationhub/iam-utils": "*",
     "@wice-devs/cfm": "1.0.8",
     "backend-commons-lib": "1.1.3",

--- a/services/flow-repository/package.json
+++ b/services/flow-repository/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-repository",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "description": "Stores and manages integration flows.",
   "main": "index.js",
   "scripts": {

--- a/services/logic-gateway/package.json
+++ b/services/logic-gateway/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@basaas/node-logger": "1.1.5",
-    "@openintegrationhub/event-bus": "^1.1.3",
-    "@openintegrationhub/iam-utils": "^1.6.2",
+    "@openintegrationhub/event-bus": "*",
+    "@openintegrationhub/iam-utils": "*",
     "base64url": "3.0.1",
     "dotenv": "6.2.0",
     "morgan": "^1.9.1",

--- a/services/meta-data-repository/package.json
+++ b/services/meta-data-repository/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meta-data-repository",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "TBD",
   "main": "index.js",
   "author": "Basaas GmbH",
@@ -31,7 +31,6 @@
     "mongoose": "5.11.8",
     "morgan": "1.9.1",
     "multer": "1.4.2",
-
     "qs": "6.10.1",
     "readdirp": "3.2.0",
     "request": "2.88.0",

--- a/services/secret-service/package.json
+++ b/services/secret-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secret-service",
-  "version": "2.5.3",
+  "version": "2.6.0",
   "description": "Service to manage Keys/Tokens of external services",
   "main": "index.js",
   "author": "Basaas GmbH",
@@ -30,9 +30,8 @@
     "moment": "2.29.1",
     "mongoose": "5.11.8",
     "morgan": "1.10.0",
-    "node-fetch":"2.6.1",
+    "node-fetch": "2.6.1",
     "oauth": "0.9.15",
-
     "qs": "6.10.1",
     "swagger-ui-express": "4.1.5"
   },

--- a/services/snapshots-service/package.json
+++ b/services/snapshots-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snapshots-service",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Service for managing flow snapshots",
   "main": "dist/index.js",
   "directories": {

--- a/services/template-repository/package.json
+++ b/services/template-repository/package.json
@@ -1,10 +1,10 @@
 {
   "name": "template-repository",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "Holds reproducible templates which can be used to generate flows.",
   "repository": {
-    "type" : "git",
-    "url" : "https://github.com/openintegrationhub/openintegrationhub.git",
+    "type": "git",
+    "url": "https://github.com/openintegrationhub/openintegrationhub.git",
     "directory": "services/template-repository"
   },
   "main": "index.js",

--- a/services/webhooks/package.json
+++ b/services/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webhooks",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "description": "Standalone version of elastic.io platform",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
```
lib/component-orchestrator: 1.2.6 -> 1.3.0
lib/component-repository: 0.1.4 -> 0.2.0
lib/ferryman: 1.5.7 -> 1.6.0
lib/webhooks: 1.2.2 -> 1.3.0

services/component-orchestrator: 1.2.11 -> 1.3.0
services/data-hub: 0.0.11 -> 0.1.0
services/flow-repository: 1.0.7 -> 1.1.0
services/meta-data-repository: 0.1.4 -> 0.2.0
services/secret-service: 2.5.3 -> 2.6.0
services/snapshots-service: 0.1.3 -> 0.2.0
services/template-repository: 0.1.5 -> 0.2.0
services/component-repository: 1.2.2 -> 1.3.0
services/webhooks: 1.1.5 -> 1.2.0
```

- [x] new lib versions published