### PR TITLE
Adjusted the example rabbitmq deployment to persist data

### DIFF
--- a/platform/rabbitmq.yaml
+++ b/platform/rabbitmq.yaml
@@ -41,7 +41,10 @@ spec:
       restartPolicy: Always
       terminationGracePeriodSeconds: 30
       containers:
-      - name: rabbitmq
+      - env:
+        - name: RABBITMQ_NODENAME
+          value: rabbitmq@rabbitmq-service
+        name: rabbitmq
         image: "rabbitmq:management"
         envFrom: []
         livenessProbe:
@@ -49,9 +52,17 @@ spec:
             port: 5672
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /var/lib/rabbitmq/mnesia
+          name: rabbitvolume
         imagePullPolicy: Always
         securityContext:
           privileged: false
+      hostname: rabbitmq-service
+      volumes:
+      - name: rabbitvolume
+        persistentVolumeClaim:
+          claimName: rabbitmq-pvc
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/platform/volumeClaim.yaml
+++ b/platform/volumeClaim.yaml
@@ -28,3 +28,18 @@ spec:
   resources:
     requests:
       storage: 1Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rabbitmq-pvc
+  namespace: oih-dev-ns
+  labels:
+    app: rabbitmq
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: standard-rwo
+  resources:
+    requests:
+      storage: 1Gi


### PR DESCRIPTION
**What has changed?**

Added a persistent volume to the example Rabbitmq deployment. This allows the queue to persist data between pod restarts, preventing data loss in that event. Additionally, this fixes the issue that queue user credential data would be lost on pod restart, which up until now required all running components to be restarted to restore their connectivity.

**What is still open or a known issue?**

For full scalable redundancy, a StatefulSet k8s deployment may be more ideal. However, that would be fairly specific to the deployment use case, and as such beyond the scope of these example files.

**Release Notes**

<!--
Improved example Rabbitmq Deployment to allow for queue data persistence.
-->
