### PR TITLE
Replaced 404 responses in some services

### DIFF
--- a/services/audit-log/app/api/controllers/log.js
+++ b/services/audit-log/app/api/controllers/log.js
@@ -16,7 +16,7 @@ const router = express.Router();
 
 const log = require('../../config/logger'); // eslint-disable-line
 
-// Gets all flows
+// Gets all logs
 router.get('/', jsonParser, can(config.logReadPermission), async (req, res) => {
   let pageSize = 10;
   let pageNumber = 1;
@@ -44,9 +44,7 @@ router.get('/', jsonParser, can(config.logReadPermission), async (req, res) => {
     sortField,
     sortOrder);
 
-  if (response.data.length === 0 && !res.headersSent) {
-    return res.status(404).send({ errors: [{ message: 'No logs found', code: 404 }] });
-  } if (!res.headersSent) {
+  if (!res.headersSent) {
     response.meta.page = pageNumber;
     response.meta.perPage = pageSize;
     response.meta.totalPages = Math.ceil(response.meta.total / pageSize);

--- a/services/audit-log/app/api/controllers/push.js
+++ b/services/audit-log/app/api/controllers/push.js
@@ -22,7 +22,7 @@ const log = require('../../config/logger'); // eslint-disable-line
 // ajv.addSchema(payloadSchema);
 // const validator = ajv.compile(schema);
 
-// Gets all logs
+// Create new log
 router.post('/', jsonParser, can(config.logPushPermission), async (req, res) => {
   const message = req.body;
 

--- a/services/audit-log/app/api/swagger/swagger.json
+++ b/services/audit-log/app/api/swagger/swagger.json
@@ -94,9 +94,6 @@
           },
           "401": {
             "description": "Missing authorization header. Login via the IAM to receive a token."
-          },
-          "404": {
-            "description": "No logs associated with the current tenant could be found in the repository."
           }
         }
       },

--- a/services/audit-log/test/test.js
+++ b/services/audit-log/test/test.js
@@ -219,8 +219,9 @@ describe('Log Operations', () => {
       })
       .set('Authorization', 'Bearer adminToken');
 
-    expect(res.status).toEqual(404);
+    expect(res.status).toEqual(200);
     expect(res.text).not.toBeNull();
+    expect(res.body.data).toHaveLength(0);
   });
 
   test('should find no logs when filtering over an absent attribute', async () => {
@@ -233,8 +234,9 @@ describe('Log Operations', () => {
       })
       .set('Authorization', 'Bearer adminToken');
 
-    expect(res.status).toEqual(404);
+    expect(res.status).toEqual(200);
     expect(res.text).not.toBeNull();
+    expect(res.body.data).toHaveLength(0);
   });
 
   test('should anonymyse a user', async () => {

--- a/services/flow-repository/app/api/controllers/flow.js
+++ b/services/flow-repository/app/api/controllers/flow.js
@@ -117,10 +117,6 @@ router.get('/', jsonParser, can(config.flowReadPermission), async (req, res) => 
 
   const response = await storage.getFlows(req.user, pageSize, pageNumber, searchString, filters, sortField, sortOrder);
 
-  if (response.data.length === 0 && !res.headersSent) {
-    return res.status(404).send({ errors: [{ message: 'No flows found', code: 404 }] });
-  }
-
   response.meta.page = pageNumber;
   response.meta.perPage = pageSize;
   response.meta.totalPages = Math.ceil(response.meta.total / pageSize);

--- a/services/flow-repository/app/api/swagger/swagger.json
+++ b/services/flow-repository/app/api/swagger/swagger.json
@@ -124,9 +124,6 @@
                 }
               }
             }
-          },
-          "404": {
-            "description": "No flows associated with the current user could be found in the repository."
           }
         }
       },

--- a/services/flow-repository/test/test.js
+++ b/services/flow-repository/test/test.js
@@ -567,9 +567,8 @@ describe('Flow Operations', () => {
       .get('/flows/')
       .set('Authorization', 'Bearer guestToken');
 
-    expect(res.status).toEqual(404);
-    expect(res.body).not.toBeNull();
-    expect(res.body.errors[0].message).toEqual('No flows found');
+    expect(res.status).toEqual(200);
+    expect(res.body.data).toHaveLength(0);
   });
 
   test('should not show the flow to another users get', async () => {

--- a/services/governance-service/app/api/controllers/event.js
+++ b/services/governance-service/app/api/controllers/event.js
@@ -113,10 +113,6 @@ router.get('/', jsonParser, can(config.flowReadPermission), async (req, res) => 
 
   const response = await storage.getProvenanceEvents(req.user, pageSize, pageNumber, filters, sortField, sortOrder, from, until);
 
-  if (response.data.length === 0 && !res.headersSent) {
-    return res.status(404).send({ errors: [{ message: 'No ProvenanceEvents found', code: 404 }] });
-  }
-
   response.meta.page = pageNumber;
   response.meta.perPage = pageSize;
   response.meta.totalPages = Math.ceil(response.meta.total / pageSize);

--- a/services/governance-service/app/api/controllers/storedFunction.js
+++ b/services/governance-service/app/api/controllers/storedFunction.js
@@ -135,10 +135,6 @@ router.get('/', jsonParser, can(config.flowReadPermission), async (req, res) => 
 
   const response = await storage.getStoredFunctions(req.user, pageSize, pageNumber, filters, sortField, sortOrder, from, until, names);
 
-  if (response.data.length === 0 && !res.headersSent) {
-    return res.status(404).send({ errors: [{ message: 'No stored functions found', code: 404 }] });
-  }
-
   response.meta.page = pageNumber;
   response.meta.perPage = pageSize;
   response.meta.totalPages = Math.ceil(response.meta.total / pageSize);

--- a/services/governance-service/app/api/swagger/swagger.json
+++ b/services/governance-service/app/api/swagger/swagger.json
@@ -108,9 +108,6 @@
                 }
               }
             }
-          },
-          "404": {
-            "description": "No Events could be found."
           }
         }
       }

--- a/services/template-repository/app/api/controllers/flowTemplate.js
+++ b/services/template-repository/app/api/controllers/flowTemplate.js
@@ -110,10 +110,6 @@ router.get('/', jsonParser, can(config.flowTemplateReadPermission), async (req, 
 
   const response = await storage.getTemplates(req.user, pageSize, pageNumber, searchString, filters, sortField, sortOrder);
 
-  if (response.data.length === 0 && !res.headersSent) {
-    return res.status(404).send({ errors: [{ message: 'No templates found', code: 404 }] });
-  }
-
   response.meta.page = pageNumber;
   response.meta.perPage = pageSize;
   response.meta.totalPages = Math.ceil(response.meta.total / pageSize);
@@ -234,7 +230,7 @@ router.get('/:id', jsonParser, can(config.flowTemplateReadPermission), async (re
   const template = await storage.getTemplateById(templateId, req.user);
 
   if (!template) {
-    res.status(404).send({ errors: [{ message: 'No template found', code: 404 }] });
+    res.status(404).send({ errors: [{ message: 'Template not found', code: 404 }] });
   } else {
     const response = {
       data: template,

--- a/services/template-repository/app/api/swagger/swagger.json
+++ b/services/template-repository/app/api/swagger/swagger.json
@@ -113,9 +113,6 @@
                 }
               }
             }
-          },
-          "404": {
-            "description": "No flows templates associated with the current user could be found in the repository."
           }
         }
       },
@@ -207,7 +204,7 @@
             }
           },
           "404": {
-            "description": "No Flow with this id was found."
+            "description": "Template not found"
           }
         }
       },
@@ -501,7 +498,7 @@
             "description": "User is not authorised to get logs."
           },
           "404": {
-            "description": "No Flow with this id was found."
+            "description": "Template not found"
           }
         }
       }

--- a/services/template-repository/test/test.js
+++ b/services/template-repository/test/test.js
@@ -259,7 +259,7 @@ describe('Template Validation', () => {
       });
     expect(res.status).toEqual(400);
     expect(res.body.errors).toHaveLength(3);
-    expect(res.body.errors[1].message).toEqual('Cast to ObjectID failed for value "abc" at path "componentId"');
+    expect(res.body.errors[1].message).toEqual('Cast to ObjectId failed for value "abc" at path "componentId"');
     expect(res.body.errors[0].message).toEqual('Cast to ObjectID failed for value "IncorrectSecret" at path "credentials_id"');
     expect(res.body.errors[2].message).toEqual('Flow Templates with more than one node require edges.');
   });

--- a/services/template-repository/test/test.js
+++ b/services/template-repository/test/test.js
@@ -259,9 +259,9 @@ describe('Template Validation', () => {
       });
     expect(res.status).toEqual(400);
     expect(res.body.errors).toHaveLength(3);
-    expect(res.body.errors[1].message).toEqual('Cast to ObjectId failed for value "abc" at path "componentId"');
-    expect(res.body.errors[0].message).toEqual('Cast to ObjectID failed for value "IncorrectSecret" at path "credentials_id"');
-    expect(res.body.errors[2].message).toEqual('Flow Templates with more than one node require edges.');
+    // expect(res.body.errors[0].message).toEqual('Cast to ObjectID failed for value "IncorrectSecret" at path "credentials_id"');
+    // expect(res.body.errors[1].message).toEqual('Cast to ObjectID failed for value "abc" at path "componentId"');
+    // expect(res.body.errors[2].message).toEqual('Flow Templates with more than one node require edges.');
   });
 
   test('should refuse a template with malformed edges', async () => {

--- a/services/template-repository/test/test.js
+++ b/services/template-repository/test/test.js
@@ -259,8 +259,8 @@ describe('Template Validation', () => {
       });
     expect(res.status).toEqual(400);
     expect(res.body.errors).toHaveLength(3);
-    expect(res.body.errors[1].message).toEqual('Cast to ObjectId failed for value "abc" at path "componentId"');
-    expect(res.body.errors[0].message).toEqual('Cast to ObjectId failed for value "IncorrectSecret" at path "credentials_id"');
+    expect(res.body.errors[1].message).toEqual('Cast to ObjectID failed for value "abc" at path "componentId"');
+    expect(res.body.errors[0].message).toEqual('Cast to ObjectID failed for value "IncorrectSecret" at path "credentials_id"');
     expect(res.body.errors[2].message).toEqual('Flow Templates with more than one node require edges.');
   });
 
@@ -553,7 +553,6 @@ describe('Template Operations', () => {
 
     expect(res.status).toEqual(200);
     expect(res.body).not.toBeNull();
-    expect(res.body.errors[0].message).toEqual('No templates found');
   });
 
   test('should not show the template to another users get', async () => {

--- a/services/template-repository/test/test.js
+++ b/services/template-repository/test/test.js
@@ -551,7 +551,7 @@ describe('Template Operations', () => {
       .get('/templates/')
       .set('Authorization', 'Bearer guestToken');
 
-    expect(res.status).toEqual(404);
+    expect(res.status).toEqual(200);
     expect(res.body).not.toBeNull();
     expect(res.body.errors[0].message).toEqual('No templates found');
   });
@@ -563,7 +563,7 @@ describe('Template Operations', () => {
 
     expect(res.status).toEqual(404);
     expect(res.body).not.toBeNull();
-    expect(res.body.errors[0].message).toEqual('No template found');
+    expect(res.body.errors[0].message).toEqual('Template not found');
   });
 
   test('should return 400 when attempting to get an invalid id', async () => {
@@ -582,7 +582,7 @@ describe('Template Operations', () => {
 
     expect(res.status).toEqual(404);
     expect(res.body).not.toBeNull();
-    expect(res.body.errors[0].message).toEqual('No template found');
+    expect(res.body.errors[0].message).toEqual('Template not found');
   });
 
   test('should add a second template', async () => {
@@ -843,7 +843,7 @@ describe('Cleanup', () => {
       .set('Authorization', 'Bearer adminToken');
     expect(res.status).toEqual(404);
     expect(res.body).not.toBeNull();
-    expect(res.body.errors[0].message).toEqual('No template found');
+    expect(res.body.errors[0].message).toEqual('Template not found');
   });
 });
 

--- a/services/template-repository/test/test.js
+++ b/services/template-repository/test/test.js
@@ -259,9 +259,9 @@ describe('Template Validation', () => {
       });
     expect(res.status).toEqual(400);
     expect(res.body.errors).toHaveLength(3);
-    // expect(res.body.errors[0].message).toEqual('Cast to ObjectID failed for value "IncorrectSecret" at path "credentials_id"');
-    // expect(res.body.errors[1].message).toEqual('Cast to ObjectID failed for value "abc" at path "componentId"');
-    // expect(res.body.errors[2].message).toEqual('Flow Templates with more than one node require edges.');
+    expect(res.body.errors[0].message).toEqual('Cast to ObjectId failed for value "IncorrectSecret" at path "credentials_id"');
+    expect(res.body.errors[1].message).toEqual('Cast to ObjectId failed for value "abc" at path "componentId"');
+    expect(res.body.errors[2].message).toEqual('Flow Templates with more than one node require edges.');
   });
 
   test('should refuse a template with malformed edges', async () => {


### PR DESCRIPTION

**What has changed?**

- In the audit-log service the get endpoint '/' now returns an empty array when there is no data.
- In the flow service the get endpoint '/' to get all flows now returns an empty array when there is no data.
- In the governance-service service the get endpoint to get all events and all stored functions now return an empty array when there is no data.
- In the template-repository service the get endpoint '/' to get all templates now returns an empty array when there is no data.

**Does a specific change require especially careful review?**

_There are some breaking changes in the services mentioned below_


**Release Notes**

Replaced 404 responses in endpoints with empty arrays in audit-log, flow-repository, governance-service and template-repository services.
