### PR TITLE
Made permission checking stricter, defaulting to false

### DIFF
--- a/services/governance-service/.eslintignore
+++ b/services/governance-service/.eslintignore
@@ -1,2 +1,3 @@
 coverage/
 node_modules/
+app/config/functionsCache/

--- a/services/governance-service/app/api/controllers/applyPolicy.js
+++ b/services/governance-service/app/api/controllers/applyPolicy.js
@@ -117,7 +117,7 @@ router.post('/', jsonParser, async (req, res) => {
   }
 
   let result = {
-    passes: true,
+    passes: false,
     data,
   };
 
@@ -145,7 +145,6 @@ router.post('/', jsonParser, async (req, res) => {
   }
 
   // Repeat the process with permissions and their constraints
-
   if (metadata.policy.permission && metadata.policy.permission.length) {
     for (let i = 0; i < metadata.policy.permission.length; i += 1) {
       const currentPermission = metadata.policy.permission[i];
@@ -159,9 +158,14 @@ router.post('/', jsonParser, async (req, res) => {
         if (passes === false) {
           result.passes = false;
           break;
+        } else {
+          result.passes = true;
         }
       }
     }
+  } else if (action) {
+    // Default to false if no permissions at all are present.
+    result.passes = false;
   }
 
   return res.status(200).send(result);

--- a/services/governance-service/app/config/defaultFunctions.js
+++ b/services/governance-service/app/config/defaultFunctions.js
@@ -128,13 +128,13 @@ const defaultFunctions = [
     },
   },
   {
-    name: 'smallerThen',
+    name: 'smallerThan',
     code: (data, permission) => {
       let passes = false;
       const returnData = Object.assign({}, data);
 
       if (permission.constraint && permission.constraint.operator) {
-        if (permission.constraint.operator === 'smallerThen') {
+        if (permission.constraint.operator === 'smallerThan') {
           const result = getValuesFromData(returnData, permission.constraint.leftOperand);
           if (result.found) {
             if (Array.isArray(result.value)) {
@@ -161,13 +161,13 @@ const defaultFunctions = [
     },
   },
   {
-    name: 'biggerThen',
+    name: 'biggerThan',
     code: (data, permission) => {
       let passes = false;
       const returnData = Object.assign({}, data);
 
       if (permission.constraint && permission.constraint.operator) {
-        if (permission.constraint.operator === 'biggerThen') {
+        if (permission.constraint.operator === 'biggerThan') {
           const result = getValuesFromData(returnData, permission.constraint.leftOperand);
           if (result.found) {
             if (Array.isArray(result.value)) {

--- a/services/governance-service/package-lock.json
+++ b/services/governance-service/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "governance-service",
-  "version": "1.1.5",
+  "version": "1.1.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.1.5",
+      "version": "1.1.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@openintegrationhub/event-bus": "^1.2.5",
@@ -18,6 +18,8 @@
         "dot-prop": "^6.0.1",
         "express": "^4.17.1",
         "mongoose": "5.11.8",
+        "request": "^2.87.0",
+        "request-promise": "^4.2.5",
         "swagger-ui-express": "^4.1.4"
       },
       "devDependencies": {
@@ -12119,6 +12121,38 @@
         "node": ">= 4"
       }
     },
+    "node_modules/request-promise": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.6.tgz",
+      "integrity": "sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==",
+      "deprecated": "request-promise has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
+      "dependencies": {
+        "bluebird": "^3.5.0",
+        "request-promise-core": "1.1.4",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "request": "^2.34"
+      }
+    },
+    "node_modules/request-promise-core": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+      "dependencies": {
+        "lodash": "^4.17.19"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "request": "^2.34"
+      }
+    },
     "node_modules/request-promise-native": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
@@ -12132,21 +12166,6 @@
       },
       "engines": {
         "node": ">=0.12.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request-promise-native/node_modules/request-promise-core": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-      "dev": true,
-      "dependencies": {
-        "lodash": "^4.17.19"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       },
       "peerDependencies": {
         "request": "^2.34"
@@ -24327,6 +24346,25 @@
         "uuid": "^3.3.2"
       }
     },
+    "request-promise": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.6.tgz",
+      "integrity": "sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==",
+      "requires": {
+        "bluebird": "^3.5.0",
+        "request-promise-core": "1.1.4",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+      "requires": {
+        "lodash": "^4.17.19"
+      }
+    },
     "request-promise-native": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
@@ -24336,17 +24374,6 @@
         "request-promise-core": "1.1.4",
         "stealthy-require": "^1.1.1",
         "tough-cookie": "^2.3.3"
-      },
-      "dependencies": {
-        "request-promise-core": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-          "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.19"
-          }
-        }
       }
     },
     "require_optional": {

--- a/services/governance-service/package.json
+++ b/services/governance-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "governance-service",
-  "version": "1.1.9",
+  "version": "1.2.0",
   "description": "Stores provenance events and other governance related data.",
   "main": "index.js",
   "scripts": {

--- a/services/governance-service/test/applyPolicy.test.js
+++ b/services/governance-service/test/applyPolicy.test.js
@@ -81,6 +81,94 @@ describe('applyPolicy Operations', () => {
     expect(res.body.data.birthday).toEqual('01.01.1970');
   });
 
+  test('should refuse to pass if no matching permission is found', async () => {
+    const body = {
+      data: {
+        firstName: 'Jane',
+        lastName: 'Doe',
+        birthday: '01.01.1970',
+        categories: [
+          {
+            label: 'Somecategory',
+          },
+          {
+            label: 'Customer',
+          },
+        ],
+      },
+      metadata: {
+        applicationUid: 'google',
+        recordUid: 'people/q308tz8adv088q8z',
+        policy: {
+          permission: [{
+            action: 'publish',
+            constraint: {
+              leftOperand: 'categories.label',
+              operator: 'equals',
+              rightOperand: 'Customer',
+            },
+          }],
+        },
+      },
+    };
+
+    const res = await request
+      .post('/applyPolicy')
+      .query({
+        action: 'distribute',
+      })
+      .set('Authorization', 'Bearer adminToken')
+      .set('accept', 'application/json')
+      .set('Content-Type', 'application/json')
+      .send(body);
+
+    expect(res.status).toEqual(200);
+    expect(res.body.passes).toEqual(false);
+    expect(res.body.data.firstName).toEqual('Jane');
+    expect(res.body.data.lastName).toEqual('Doe');
+    expect(res.body.data.birthday).toEqual('01.01.1970');
+  });
+
+  test('should refuse to pass if no permission at all is present', async () => {
+    const body = {
+      data: {
+        firstName: 'Jane',
+        lastName: 'Doe',
+        birthday: '01.01.1970',
+        categories: [
+          {
+            label: 'Somecategory',
+          },
+          {
+            label: 'Customer',
+          },
+        ],
+      },
+      metadata: {
+        applicationUid: 'google',
+        recordUid: 'people/q308tz8adv088q8z',
+        policy: {
+        },
+      },
+    };
+
+    const res = await request
+      .post('/applyPolicy')
+      .query({
+        action: 'distribute',
+      })
+      .set('Authorization', 'Bearer adminToken')
+      .set('accept', 'application/json')
+      .set('Content-Type', 'application/json')
+      .send(body);
+
+    expect(res.status).toEqual(200);
+    expect(res.body.passes).toEqual(false);
+    expect(res.body.data.firstName).toEqual('Jane');
+    expect(res.body.data.lastName).toEqual('Doe');
+    expect(res.body.data.birthday).toEqual('01.01.1970');
+  });
+
   test('should verify a simple constraint with equals', async () => {
     const body = {
       data: {
@@ -276,7 +364,7 @@ describe('applyPolicy Operations', () => {
     expect(res.body.data.birthday).toEqual('01.01.1970');
   });
 
-  test('should verify a simple constraint with smallerThen', async () => {
+  test('should verify a simple constraint with smallerThan', async () => {
     const body = {
       data: {
         firstName: 'Jane',
@@ -291,7 +379,7 @@ describe('applyPolicy Operations', () => {
             action: 'distribute',
             constraint: {
               leftOperand: 'timestamp',
-              operator: 'smallerThen',
+              operator: 'smallerThan',
               rightOperand: 12345,
             },
           }],
@@ -317,7 +405,7 @@ describe('applyPolicy Operations', () => {
   });
 
 
-  test('should apply a simple constraint with smallerThen', async () => {
+  test('should apply a simple constraint with smallerThan', async () => {
     const body = {
       data: {
         firstName: 'Jane',
@@ -332,7 +420,7 @@ describe('applyPolicy Operations', () => {
             action: 'distribute',
             constraint: {
               leftOperand: 'timestamp',
-              operator: 'smallerThen',
+              operator: 'smallerThan',
               rightOperand: 12345,
             },
           }],
@@ -359,7 +447,7 @@ describe('applyPolicy Operations', () => {
 
   // ////
 
-  test('should verify a simple constraint with biggerThen', async () => {
+  test('should verify a simple constraint with biggerThan', async () => {
     const body = {
       data: {
         firstName: 'Jane',
@@ -374,7 +462,7 @@ describe('applyPolicy Operations', () => {
             action: 'distribute',
             constraint: {
               leftOperand: 'timestamp',
-              operator: 'biggerThen',
+              operator: 'biggerThan',
               rightOperand: 1234,
             },
           }],
@@ -400,7 +488,7 @@ describe('applyPolicy Operations', () => {
   });
 
 
-  test('should apply a simple constraint with biggerThen', async () => {
+  test('should apply a simple constraint with biggerThan', async () => {
     const body = {
       data: {
         firstName: 'Jane',
@@ -415,7 +503,7 @@ describe('applyPolicy Operations', () => {
             action: 'distribute',
             constraint: {
               leftOperand: 'timestamp',
-              operator: 'biggerThen',
+              operator: 'biggerThan',
               rightOperand: 12345,
             },
           }],


### PR DESCRIPTION
**What has changed?**

Tightened up the permission checking to avoid passing results being given by default. If an action is provided, a pass will only be given if and only if a matching permission with fulfilled constraints is present. In all other cases, the service will default to no pass.

**Release Notes**

<!--
Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text may be used in our release notes.
-->
