### PR TITLE
Updated IAM OpenAPI doc

### DIFF
--- a/services/iam/doc/openapi.json
+++ b/services/iam/doc/openapi.json
@@ -192,7 +192,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Tenant"
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    }
+                  }
                 }
               }
             }

--- a/services/iam/doc/openapi.json
+++ b/services/iam/doc/openapi.json
@@ -1,7 +1,7 @@
 {
   "servers": [
     {
-      "url": "https://api.example.com"
+      "url": "https://iam.example.com"
     }
   ],
   "openapi": "3.0.0",
@@ -153,9 +153,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Tenant"
+                  "type":"object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Tenant"
+                      }
+                    }  
                   }
                 }
               }
@@ -183,7 +188,14 @@
         },
         "responses": {
           "200": {
-            "description": "Success"
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Tenant"
+                }
+              }
+            }
           }
         }
       }
@@ -888,9 +900,9 @@
       "Status": {
         "type": "string",
         "enum": [
-          "active",
-          "pending",
-          "disabled"
+          "ACTIVE",
+          "PENDING",
+          "DISABLED"
         ]
       },
       "GlobalRole": {
@@ -1072,7 +1084,7 @@
         "title": "Tenant Schema",
         "type": "object",
         "properties": {
-          "id": {
+          "_id": {
             "type": "string",
             "description": "id of tenant organization"
           },


### PR DESCRIPTION
 Based on actual results from the API using a Typescript client generated from the doc

**What has changed?**

1. Example url reflects the typical iam.example.com instead of api.example.com which doesn't fit the expected pattern
1. When getting the list of tenants the schema doesn't take into account the data object wrapped around the array
1. When creating a tenant there isn't an expected return type even though the ID of the created tenant is returned. I made the return type a Tenant
1. When creating a tenant and using the lowercase statuses in the Status schema, the request will be rejected. I capitalized the statuses to match what is expected/enforced by the API
1. When returning the Tenant Schema object the ID is _id and not id as is defined in the schema

**Does a specific change require especially careful review?**

- Change 5
  - It's possible the API should be changed to return id instead of _id but that creates all kinds of breaking changes I don't want to deal with. I also didn't validate whether sometimes id is returned. In that case the schema would need both id and _id.

**Release Notes**

Improved IAM OpenAPI document to reflect nuances of the API implementation