### PR TITLE
Schema Builder will only attempt to fetch schemas which are strings

### DIFF
--- a/lib/component-repository/src/utils/fetchMetaSchemas.js
+++ b/lib/component-repository/src/utils/fetchMetaSchemas.js
@@ -25,26 +25,28 @@ async function fetchMetaSchemas(repoUrl, componentId) {
         if ('metadata' in componentData[mainKeys[i]][key]) {
           for (let j=0; j<metaKeys.length; j+=1) {
             if (metaKeys[j] in componentData[mainKeys[i]][key].metadata) {
-              let url = componentData[mainKeys[i]][key].metadata[metaKeys[j]].trim();
-              if (url[0] === '.') url = url.substr(2);
-              url = baseUrl + url;
+              if ((typeof componentData[mainKeys[i]][key].metadata[metaKeys[j]]) === 'string') {
+                let url = componentData[mainKeys[i]][key].metadata[metaKeys[j]].trim();
+                if (url[0] === '.') url = url.substr(2);
+                url = baseUrl + url;
 
-              try {
-                let schemaJson;
-                const schemaResponse = await fetch(url);
+                try {
+                  let schemaJson;
+                  const schemaResponse = await fetch(url);
 
-                if (schemaResponse.status === 200) {
-                  schemaJson = await schemaResponse.json();
+                  if (schemaResponse.status === 200) {
+                    schemaJson = await schemaResponse.json();
+                  }
+
+                  if (schemaJson) {
+                    componentData[mainKeys[i]][key].metadata[metaKeys[j]] = schemaJson;
+                    hasChanged = true;
+                  } else {
+                    console.error('Schema is not valid json:', url);
+                  }
+                } catch(e) {
+                  console.error(e);
                 }
-
-                if (schemaJson) {
-                  componentData[mainKeys[i]][key].metadata[metaKeys[j]] = schemaJson;
-                  hasChanged = true;
-                } else {
-                  console.error('Schema is not valid json:', url);
-                }
-              } catch(e) {
-                console.error(e);
               }
             }
           }


### PR DESCRIPTION
When a component.json file is encountered where the metadata is not a relative path (i.e. an object already in the file, or an empty object), the schema enrichment function of the component-repository was failing. By adding a check for string types, the enrichment now supports:
- Object Schemas
  - Includes Empty Objects
- relative paths to schemas as Strings

Other types are not supported, such as defining a basic type by string (i.e. "string", "number"). This should be placed inside a schema and referenced via path.

Fixes #1311.
