### PR TITLE
Update ingress.yaml to use networking.k8s.io/v1

### DIFF
--- a/minikube/1-Platform/ingress.yaml
+++ b/minikube/1-Platform/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: oih-dev-ingress
@@ -10,84 +10,140 @@ spec:
   - host: iam.example.com
     http:
       paths:
-      - backend:
-          serviceName: iam
-          servicePort: 3099
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: iam
+            port:
+              number: 3099
   - host: skm.example.com
     http:
       paths:
-      - backend:
-          serviceName: secret-service
-          servicePort: 3000
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: secret-service
+            port:
+              number: 3000
   - host: flow-repository.example.com
     http:
       paths:
-      - backend:
-          serviceName: flow-repository
-          servicePort: 3001
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+              name: flow-repository
+              port:
+                number: 3001
   - host: auditlog.example.com
     http:
       paths:
-      - backend:
-          serviceName: audit-log
-          servicePort: 3007
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: audit-log
+            port:
+              number: 3007
   - host: metadata.example.com
     http:
       paths:
-      - backend:
-          serviceName: meta-data-repository
-          servicePort: 3000
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: meta-data-repository
+            port:
+              number: 3000
   - host: component-repository.example.com
     http:
       paths:
-      - backend:
-          serviceName: component-repository
-          servicePort: 1234
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: component-repository
+            port:
+              number: 1234
   - host: snapshots-service.example.com
     http:
       paths:
-      - backend:
-          serviceName: snapshots-service
-          servicePort: 1234
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: snapshots-service
+            port:
+              number: 1234
   - host: webhooks.example.com
     http:
       paths:
-      - backend:
-          serviceName: webhooks
-          servicePort: 1234
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: webhooks
+            port:
+              number: 1234
   - host: web-ui.example.com
     http:
       paths:
-      - backend:
-          serviceName: web-ui
-          servicePort: 3000
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: web-ui
+            port:
+              number: 3000
   - host: attachment-storage-service.example.com
     http:
       paths:
-      - backend:
-          serviceName: attachment-storage-service
-          servicePort: 3002
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: attachment-storage-service
+            port:
+              number: 3002
   - host: data-hub.example.com
     http:
       paths:
-      - backend:
-          serviceName: data-hub-service
-          servicePort: 1234
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: data-hub-service
+            port:
+              number: 1234
   - host: ils.example.com
     http:
       paths:
-      - backend:
-          serviceName: ils
-          servicePort: 3003
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: ils
+            port:
+              number: 3003
   - host: app-directory.example.com
     http:
       paths:
-      - backend:
-          serviceName: app-directory
-          servicePort: 3000
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: app-directory
+            port:
+              number: 3000
   - host: dispatcher-service.example.com
     http:
       paths:
-      - backend:
-          serviceName: dispatcher-service
-          servicePort: 3013
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: dispatcher-service
+            port:
+              number: 3013


### PR DESCRIPTION
**What has changed?**
The `ingress.yaml` file has been modified in this PR to v1, moving off of the v1beta1 version of the file.

**Does a specific change require especially careful review?**
No.

**What is still open or a known issue?**
N/A

**Release Notes**
Currently, when running `kubectl apply -f ./1-Platform` locally (as called out in the [Getting Started Guide](https://openintegrationhub.github.io/docs/3%20-%20GettingStarted/LocalInstallationGuide.html#basic-open-integration-hub-infrastructure-setup) `kubectl` fails with the following:
```
error: unable to recognize "1-Platform/ingress.yaml": no matches for kind "Ingress" in version "networking.k8s.io/v1beta1"
```
This change addresses this error by moving this file to the `v1` api version.