### PR TITLE
Add nodeSettings to templates

### DIFF
--- a/services/template-repository/app/models/schemas/flowTemplate.js
+++ b/services/template-repository/app/models/schemas/flowTemplate.js
@@ -14,6 +14,7 @@ const node = new Schema({
   credentials_id: { type: mongoose.Types.ObjectId, maxlength: 30 },
   description: { type: String, maxlength: 100 },
   fields: {},
+  nodeSettings: {},
   authorization: {
     authType: {
       type: String,


### PR DESCRIPTION
When the `nodeSettings` field was added to flows, it was not also added to templates. This change updates the template schema to also include nodeSettings.
