### PR TITLE
Send correct message (payload) to the transform function

### DIFF
--- a/lib/ferryman/lib/ferryman.js
+++ b/lib/ferryman/lib/ferryman.js
@@ -562,7 +562,7 @@ class Ferryman {
             const transformCfg = {
                 customMapping: this.nodeSettings.transformFunction
             };
-            const transformedMsg = transform(message, transformCfg, false);
+            const transformedMsg = transform(payload, transformCfg, false);
             payload = transformedMsg;
         }
 

--- a/lib/ferryman/lib/transformer.js
+++ b/lib/ferryman/lib/transformer.js
@@ -20,7 +20,7 @@ function transform(object, cfg = {}, defaultMapping = false) {
 
         this.emit('raw-record', {
             rawRecordId,
-            payload: object.body
+            payload: object.data
         });
     }
 

--- a/lib/ferryman/package.json
+++ b/lib/ferryman/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openintegrationhub/ferryman",
   "description": "Wrapper utility for Open Integration Hub connectors",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "run.js",
   "scripts": {
     "lint": "eslint lib mocha_spec lib runGlobal.js runService.js",


### PR DESCRIPTION
Fixes #1361 by sending the `payload` parameter, which holds an OIH message, rather than the `message` parameter, which holds a RabbitMQ message.

Also passes the correct `data` object to raw data storage, rather than `body`