### PR TITLE
pass encryption key to /secrets patch handler

### DIFF
--- a/services/secret-service/src/route/secrets/index.js
+++ b/services/secret-service/src/route/secrets/index.js
@@ -183,7 +183,7 @@ class SecretsRouter {
                     data: await SecretDAO.update({
                         id: req.params.id,
                         data,
-                    }),
+                    }, req.key),
                 });
             } catch (err) {
                 log.error(err);


### PR DESCRIPTION
**What has changed?**

Encryption key is now passed to the secret service update secret route handler.

**Does a specific change require especially careful review?**

No

**What is still open or a known issue?**

None

**Release Notes**

Secret service encrypts sensitive fields when a secret is updated via a PATCH request.
