### PR TITLE
Remove Broken Reference in onUpdateSnapshot

### DIFF
--- a/lib/ferryman/lib/ferryman.js
+++ b/lib/ferryman/lib/ferryman.js
@@ -1114,7 +1114,7 @@ class Ferryman {
                     }
                     _.extend(self.snapshot, data); // updating `local` snapshot
                     // eslint-disable-next-line
-                    return self.amqpConnection.sendSnapshot(data, headers, null, this.snapshotRoutingKey);
+                    return self.amqpConnection.sendSnapshot(data, headers, null);
                 }
                 log.error('You should pass an object to the `updateSnapshot` event');
                 return false;


### PR DESCRIPTION
**What has changed?**

- Removes the fourth param, `this.snapshotRoutingKey`, from the call to `self.amqpConnection.sendSnapshot()` in Ferryman's `onUpdateSnapshot()` function

**Does a specific change require especially careful review?**

No, the param is not used in the function it is passed to.

**What is still open or a known issue?**

None

**Release Notes**

Fixes error when Ferryman attempts to auto save snapshots.

Closes #1410 "Ferryman not autosaving snapshots"