### PR TITLE
Added secret service preprocessor for OIDC auth client

### DIFF
--- a/services/secret-service/index.js
+++ b/services/secret-service/index.js
@@ -34,6 +34,7 @@ process.on('SIGINT', exitHandler.bind(null));
                 key: require('./src/adapter/key/global'),
                 preprocessor: {
                     microsoft: require('./src/adapter/preprocessor/microsoft'),
+                    oidc: require('./src/adapter/preprocessor/oidc'),
                 },
             },
             eventBus,

--- a/services/secret-service/src/adapter/preprocessor/oidc/index.js
+++ b/services/secret-service/src/adapter/preprocessor/oidc/index.js
@@ -1,0 +1,12 @@
+const jwt = require('jsonwebtoken');
+
+module.exports = async ({
+    secret,
+    // flow,
+    // authClient,
+    tokenResponse,
+}) => {
+    secret.value.id_token = tokenResponse.id_token;
+    secret.value.externalId = jwt.decode(tokenResponse.id_token).email;
+    return secret;
+};


### PR DESCRIPTION
**What has changed?**

- Secret service: Created an auth client preprocessor to map the id_token into the secret value
- Also, mapped the email in the JWT to the externalId like the Microsoft preprocessor

**Does a specific change require especially careful review?**

This functionality is modeled after other preprocessors that exist in the code and should be low risk

**What is still open or a known issue?**
N/A

**Release Notes**
Added secret service auth client preprocessor for mapping an Open ID Connect (OIDC) id_token into the secret value created from the auth client.
