### PR TITLE
Secret Service: map id_token to externalId in oidc secret preprocessor

### DIFF
--- a/services/secret-service/src/adapter/preprocessor/oidc/index.js
+++ b/services/secret-service/src/adapter/preprocessor/oidc/index.js
@@ -6,7 +6,6 @@ module.exports = async ({
     // authClient,
     tokenResponse,
 }) => {
-    secret.value.id_token = tokenResponse.id_token;
-    secret.value.externalId = jwt.decode(tokenResponse.id_token).email;
+    secret.value.externalId = tokenResponse.id_token;
     return secret;
 };


### PR DESCRIPTION
This is a follow up to #1415. I had not noticed that the id_token parameter is stripped from the secret before saving and was effectively the same as the `microsoft` preprocessor. I modified the preprocessor to set the externalId as the id_token.

**What has changed?**

- Modified id_token to be externalId in secret service `oidc` preprocessor

**Does a specific change require especially careful review?**

N/A

**What is still open or a known issue?**
There should probably be an OpenID Connect specific auth type added as a follow up

**Release Notes**
