### PR TITLE
add each value of encryptedFields array, not array as a whole

### DIFF
--- a/services/secret-service/src/dao/secret.js
+++ b/services/secret-service/src/dao/secret.js
@@ -286,7 +286,9 @@ module.exports = {
             $set: data,
             ...!conf.crypto.isDisabled ? {
                 $addToSet: {
-                    encryptedFields,
+                    encryptedFields: {
+                        $each: encryptedFields
+                    }
                 },
             } : {},
         }, {


### PR DESCRIPTION
**What has changed?**

- Calling the `update()` function in `/services/secret-service/src/dao/secret.js` adds the individual values of `encryptedFields` to the existing set of `encryptedFields`, not the array of `encryptedFields` as a whole. 

**Does a specific change require especially careful review?**
Yes, `encryptedFields` functionality is complex and used throughout the Secret Service.

**What is still open or a known issue?**
None

**Release Notes**
Fixes bug in PATCH updates to secrets

Closes #1420 