### PR TITLE
Adjusted default sorting to prevent unexpected pagination

### DIFF
--- a/services/flow-repository/app/api/controllers/flow.js
+++ b/services/flow-repository/app/api/controllers/flow.js
@@ -40,7 +40,7 @@ router.get('/', jsonParser, can(config.flowReadPermission), async (req, res) => 
   let searchString = '';
 
   const sortableFields = { createdAt: 1, updatedAt: 1, name: 1 };
-  let sortField = 'id';
+  let sortField = 'createdAt';
   let sortOrder = '1';
 
   // page[size]
@@ -91,7 +91,7 @@ router.get('/', jsonParser, can(config.flowReadPermission), async (req, res) => 
   }
 
   // sort createdAt, updatedAt and name,  Prefix -
-  if (req.query.sort !== undefined) {
+  if (req.query.sort && req.query.sort.length) {
     const array = req.query.sort.split('-');
     if (array.length === 1) {
       sortField = array[0];

--- a/services/flow-repository/package.json
+++ b/services/flow-repository/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-repository",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Stores and manages integration flows.",
   "main": "index.js",
   "scripts": {

--- a/services/flow-repository/test/test.js
+++ b/services/flow-repository/test/test.js
@@ -644,6 +644,42 @@ describe('Flow Operations', () => {
     flowId2 = j.data.id;
   });
 
+  test('should paginate flows properly', async () => {
+    const res = await request
+      .get('/flows')
+      .query({
+        'page[size]': 1,
+        'page[number]': 1,
+        'filter[status]': 0,
+      })
+      .set('Authorization', 'Bearer adminToken');
+
+    expect(res.status).toEqual(200);
+    expect(res.text).not.toBeNull();
+    const j = JSON.parse(res.text);
+
+    expect(j).not.toBeNull();
+    expect(j.data).toHaveLength(1);
+    expect(j.data[0].name).toEqual('WiceToSnazzy');
+
+    const res2 = await request
+      .get('/flows')
+      .query({
+        'page[size]': 1,
+        'page[number]': 2,
+        'filter[status]': 0,
+      })
+      .set('Authorization', 'Bearer adminToken');
+
+    expect(res2.status).toEqual(200);
+    expect(res2.text).not.toBeNull();
+    const j2 = JSON.parse(res2.text);
+
+    expect(j2).not.toBeNull();
+    expect(j2.data).toHaveLength(1);
+    expect(j2.data[0].name).toEqual('SnazzyToWice');
+  });
+
   test('should get all flows, filtered by status', async () => {
     const res = await request
       .get('/flows')


### PR DESCRIPTION
**What has changed?**

- Adjusted default sorting to avoid faulty pagination

**Release Notes**

<!--
Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text may be used in our release notes.
-->

Fixed a bug in the flow repository where pagination would show results out of order
