### PR TITLE
Now accepts string inputs for status filter

### DIFF
--- a/services/flow-repository/app/api/controllers/flow.js
+++ b/services/flow-repository/app/api/controllers/flow.js
@@ -54,9 +54,9 @@ router.get('/', jsonParser, can(config.flowReadPermission), async (req, res) => 
 
   // filter[status] 1 0
   if (req.query.filter && req.query.filter.status !== undefined) {
-    if (req.query.filter.status === '1') {
+    if (req.query.filter.status === '1' || req.query.filter.status === 'active') {
       filters.status = 'active';
-    } else if (req.query.filter.status === '0') {
+    } else if (req.query.filter.status === '0' || req.query.filter.status === 'inactive') {
       filters.status = 'inactive';
     } else if (!res.headersSent) {
       res.status(400).send({ errors: [{ message: 'Invalid filter[status] parameter', code: 400 }] });

--- a/services/flow-repository/app/api/swagger/swagger.json
+++ b/services/flow-repository/app/api/swagger/swagger.json
@@ -60,10 +60,10 @@
           {
             "name": "filter[status]",
             "in": "query",
-            "description": "Filter results by flow status. Active = 1. Inactive = 0",
+            "description": "Filter results by flow status. Accepts either string ('active' and 'inactive') or integer (1 or 0)",
             "required": false,
             "schema": {
-              "type": "integer"
+              "type": "string"
             }
           },
           {

--- a/services/flow-repository/package.json
+++ b/services/flow-repository/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-repository",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Stores and manages integration flows.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
**What has changed?**

- Unified flow repo query parameters with data model by allowing the "status" filter to accept the same values as are used in the model.
