### PR TITLE
remove optional chaining operator

### DIFF
--- a/services/webhooks/src/request-handlers/post.js
+++ b/services/webhooks/src/request-handlers/post.js
@@ -22,7 +22,7 @@ class PostRequestHandler extends RequestHandlers.Post {
         const flowUser = flow.getFlowUser();
 
         // Normalize Owner Types for sending to iam-utils GH #1422 TODO: Normalize constants, then remove this line
-        flow.owners?.forEach(x => ("type" in x) ? x.type = x.type.toUpperCase(): null);
+        flow.owners.forEach(x => ("type" in x) ? x.type = x.type.toUpperCase(): null);
         // Default to false if field doesn't exist
         const { requireWebhookAuth = false, hmacHeaderKey = DEFAULT_HMAC_HEADER_KEY, hmacAuthSecret, hmacAlgorithm = DEFAULT_HMAC_ALGORITHM, allTenantUsers=false } = flowSettings;
         if (!requireWebhookAuth) {

--- a/services/webhooks/src/request-handlers/post.js
+++ b/services/webhooks/src/request-handlers/post.js
@@ -22,7 +22,7 @@ class PostRequestHandler extends RequestHandlers.Post {
         const flowUser = flow.getFlowUser();
 
         // Normalize Owner Types for sending to iam-utils GH #1422 TODO: Normalize constants, then remove this line
-        flow.owners.forEach(x => ("type" in x) ? x.type = x.type.toUpperCase(): null);
+        flow.owners.forEach(x => ('type' in x) ? x.type = x.type.toUpperCase(): null);
         // Default to false if field doesn't exist
         const { requireWebhookAuth = false, hmacHeaderKey = DEFAULT_HMAC_HEADER_KEY, hmacAuthSecret, hmacAlgorithm = DEFAULT_HMAC_ALGORITHM, allTenantUsers=false } = flowSettings;
         if (!requireWebhookAuth) {


### PR DESCRIPTION
This branch appears to have fixed the issue we had encountered. I have tested it with Bearer authentication on my local minikube setup. 

But it looks like the webhooks-test job on CircleCI is failing on the optional chaining operator (`?.`) in `services/webhooks/src/request-handlers/post.js` on line 25. I'm guessing this is an issue with the version of node used for running the tests(?). 

I think we can simply remove the `?`, as `flow.owners` is always an array, and even an empty array can have a `.forEach()` run on it without issue.