### PR TITLE
IAM Service Docs

### DIFF
--- a/services/iam/doc/openapi.json
+++ b/services/iam/doc/openapi.json
@@ -300,7 +300,7 @@
         }
       }
     },
-    "/api/v1/tenants/:id/users": {
+    "/api/v1/tenants/{id}/users": {
       "get": {
         "tags": [
           "tenant"
@@ -373,7 +373,7 @@
         ]
       }
     },
-    "/api/v1/tenants/:id/user/:userId": {
+    "/api/v1/tenants/{id}/user/{userId}": {
       "delete": {
         "tags": [
           "tenant"
@@ -477,7 +477,7 @@
         }
       }
     },
-    "/api/v1/users/:id": {
+    "/api/v1/users/{id}": {
       "get": {
         "tags": [
           "user"
@@ -664,7 +664,7 @@
         }
       }
     },
-    "/api/v1/roles/:id": {
+    "/api/v1/roles/{id}": {
       "get": {
         "tags": [
           "role"


### PR DESCRIPTION
**What has changed?**

- Updated endpoint paths to utilize the `{parameter}` syntax rather than `:parameter`. Prior to the update, the requests were being made to hardcoded `:parameter` rather than the intended id. 

**Does a specific change require especially careful review?**
No

**What is still open or a known issue?**
N/A

**Release Notes**
Minor fixes / improvements to IAM Service OpenAPI docs
