### PR TITLE
Preprocessor azure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -118,7 +118,7 @@
 			}
 		},
 		"lib/backend-commons-lib": {
-			"version": "3.0.0",
+			"version": "2.1.0",
 			"license": "APL-2.0",
 			"dependencies": {
 				"amqplib": "0.8.0",
@@ -344,7 +344,7 @@
 		},
 		"lib/component-orchestrator": {
 			"name": "@openintegrationhub/component-orchestrator",
-			"version": "2.0.0",
+			"version": "1.5.0",
 			"license": "APL-2.0",
 			"dependencies": {
 				"@openintegrationhub/event-bus": "*",
@@ -736,7 +736,7 @@
 		},
 		"lib/ferryman": {
 			"name": "@openintegrationhub/ferryman",
-			"version": "3.0.0",
+			"version": "2.2.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"amqplib": "0.8.0",
@@ -4482,6 +4482,34 @@
 			},
 			"peerDependencies": {
 				"@material-ui/core": "^4.0.0",
+				"@types/react": "^16.8.6 || ^17.0.0",
+				"react": "^16.8.0 || ^17.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@material-ui/lab": {
+			"version": "4.11.3-deprecations.1",
+			"resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.11.3-deprecations.1.tgz",
+			"integrity": "sha512-mP53Wh3jKzPcZbvnY+hLWQmfEq8JmUP1SrR1r8S+jxMymC20/SLxMVVLb4h4pmZ0+ga232JegG0XypQ/r9I5TA==",
+			"deprecated": "You can now upgrade to @mui/lab. See the guide: https://mui.com/guides/migration-v4/",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.4.4",
+				"@material-ui/utils": "^4.11.2",
+				"clsx": "^1.0.4",
+				"prop-types": "^15.7.2",
+				"react-is": "^16.8.0 || ^17.0.0"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			},
+			"peerDependencies": {
+				"@material-ui/core": "^4.11.3-deprecations.1",
 				"@types/react": "^16.8.6 || ^17.0.0",
 				"react": "^16.8.0 || ^17.0.0",
 				"react-dom": "^16.8.0 || ^17.0.0"
@@ -32300,7 +32328,7 @@
 			"license": "MIT"
 		},
 		"services/component-orchestrator": {
-			"version": "2.0.0",
+			"version": "1.7.0",
 			"license": "APL-2.0",
 			"dependencies": {
 				"@openintegrationhub/component-orchestrator": "*",
@@ -33130,7 +33158,7 @@
 			}
 		},
 		"services/data-hub": {
-			"version": "0.3.2",
+			"version": "0.3.3",
 			"license": "UNLICENSED",
 			"dependencies": {
 				"@openintegrationhub/event-bus": "*",
@@ -38617,6 +38645,7 @@
 				"eslint-plugin-import": "2.22.1",
 				"eslint-plugin-jest": "24.1.3",
 				"jest": "26.6.0",
+				"jest-environment-node": "^26.6.2",
 				"mongodb": "3.6.3",
 				"mongodb-memory-server": "7.4.0",
 				"nock": "13.0.5",
@@ -38718,6 +38747,23 @@
 			"version": "1.0.0",
 			"dev": true,
 			"license": "MIT"
+		},
+		"services/secret-service/node_modules/jest-environment-node": {
+			"version": "26.6.2",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.6.2.tgz",
+			"integrity": "sha512-zhtMio3Exty18dy8ee8eJ9kjnRyZC1N4C1Nt/VShN1apyXc8rWGtJ9lI7vqiWcyyXS4BVSEn9lxAM2D+07/Tag==",
+			"dev": true,
+			"dependencies": {
+				"@jest/environment": "^26.6.2",
+				"@jest/fake-timers": "^26.6.2",
+				"@jest/types": "^26.6.2",
+				"@types/node": "*",
+				"jest-mock": "^26.6.2",
+				"jest-util": "^26.6.2"
+			},
+			"engines": {
+				"node": ">= 10.14.2"
+			}
 		},
 		"services/secret-service/node_modules/mongodb": {
 			"version": "3.6.3",
@@ -39638,7 +39684,7 @@
 			"license": "MIT"
 		},
 		"services/web-ui": {
-			"version": "0.4.5",
+			"version": "0.4.6",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@basaas/node-logger": "1.1.5",
@@ -39653,6 +39699,7 @@
 			"devDependencies": {
 				"@material-ui/core": "4.11.3",
 				"@material-ui/icons": "4.11.2",
+				"@material-ui/lab": "4.11.3-deprecations.1",
 				"@material-ui/styles": "4.11.3",
 				"axios": "0.24.0",
 				"babel-eslint": "^10.1.0",
@@ -41764,6 +41811,19 @@
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.4.4"
+			}
+		},
+		"@material-ui/lab": {
+			"version": "4.11.3-deprecations.1",
+			"resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.11.3-deprecations.1.tgz",
+			"integrity": "sha512-mP53Wh3jKzPcZbvnY+hLWQmfEq8JmUP1SrR1r8S+jxMymC20/SLxMVVLb4h4pmZ0+ga232JegG0XypQ/r9I5TA==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"@material-ui/utils": "^4.11.2",
+				"clsx": "^1.0.4",
+				"prop-types": "^15.7.2",
+				"react-is": "^16.8.0 || ^17.0.0"
 			}
 		},
 		"@material-ui/styles": {
@@ -63779,6 +63839,7 @@
 				"eslint-plugin-jest": "24.1.3",
 				"express": "4.17.1",
 				"jest": "26.6.0",
+				"jest-environment-node": "^26.6.2",
 				"jsonwebtoken": "8.5.1",
 				"lru-cache": "6.0.0",
 				"moment": "2.29.1",
@@ -63851,6 +63912,20 @@
 				"isarray": {
 					"version": "1.0.0",
 					"dev": true
+				},
+				"jest-environment-node": {
+					"version": "26.6.2",
+					"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.6.2.tgz",
+					"integrity": "sha512-zhtMio3Exty18dy8ee8eJ9kjnRyZC1N4C1Nt/VShN1apyXc8rWGtJ9lI7vqiWcyyXS4BVSEn9lxAM2D+07/Tag==",
+					"dev": true,
+					"requires": {
+						"@jest/environment": "^26.6.2",
+						"@jest/fake-timers": "^26.6.2",
+						"@jest/types": "^26.6.2",
+						"@types/node": "*",
+						"jest-mock": "^26.6.2",
+						"jest-util": "^26.6.2"
+					}
 				},
 				"mongodb": {
 					"version": "3.6.3",
@@ -66588,6 +66663,7 @@
 				"@basaas/node-logger": "1.1.5",
 				"@material-ui/core": "4.11.3",
 				"@material-ui/icons": "4.11.2",
+				"@material-ui/lab": "4.11.3-deprecations.1",
 				"@material-ui/styles": "4.11.3",
 				"axios": "0.24.0",
 				"babel-eslint": "^10.1.0",

--- a/services/secret-service/index.js
+++ b/services/secret-service/index.js
@@ -35,6 +35,7 @@ process.on('SIGINT', exitHandler.bind(null));
                 preprocessor: {
                     microsoft: require('./src/adapter/preprocessor/microsoft'),
                     oidc: require('./src/adapter/preprocessor/oidc'),
+                    azure: require('./src/adapter/preprocessor/azure'),
                 },
             },
             eventBus,

--- a/services/secret-service/src/adapter/preprocessor/azure/index.js
+++ b/services/secret-service/src/adapter/preprocessor/azure/index.js
@@ -1,0 +1,13 @@
+const jwt = require('jsonwebtoken');
+
+module.exports = async ({
+    secret,
+    // flow,
+    // authClient,
+    tokenResponse,
+}) => {
+    // Need to request oidc and profile scopes to get the correct properties.
+    const payload = jwt.decode(tokenResponse.id_token);
+    secret.value.externalId = payload.preferred_username;
+    return secret;
+};

--- a/services/secret-service/src/auth-flow-manager/index.js
+++ b/services/secret-service/src/auth-flow-manager/index.js
@@ -99,7 +99,7 @@ async function requestHelper(url, form) {
         .then(checkStatus)
         .then((response) => response.json())
         .catch((error) => { throw new Error(error); }); */
-    log.debug(`requestHelper: url: ${url} body params: ${JSON.stringify(params)}`);
+    log.debug(`requestHelper: url: ${url} body params: ${params.toString()}`);
     const response = await fetch(url, {
         method: 'POST',
         headers: {

--- a/services/secret-service/src/auth-flow-manager/index.js
+++ b/services/secret-service/src/auth-flow-manager/index.js
@@ -99,6 +99,7 @@ async function requestHelper(url, form) {
         .then(checkStatus)
         .then((response) => response.json())
         .catch((error) => { throw new Error(error); }); */
+    log.debug(`requestHelper: url: ${url} body params: ${JSON.stringify(params)}`);
     const response = await fetch(url, {
         method: 'POST',
         headers: {
@@ -239,6 +240,7 @@ module.exports = {
         }
     },
     async refresh(authClient, secret) {
+        log.debug(`Refreshing auth ${secret && secret._id ? secret._id : ''} client id: ${authClient && authClient._id ? authClient._id : ''}`);
         switch (authClient.type) {
         case OA2_AUTHORIZATION_CODE: {
             const { clientId, clientSecret, refreshWithScope } = authClient;
@@ -271,7 +273,7 @@ module.exports = {
         flow, authClient, secret, tokenResponse, localMiddleware,
     }) {
         if (authClient.preprocessor) {
-            const adapter = dotProp.get(localMiddleware, authClient.preprocessor);
+            const adapter = dotProp.get(localMiddleware.preprocessor, authClient.preprocessor);
             if (!adapter) {
                 throw (new Error(`Missing preprocessor ${authClient.preprocessor}`));
             }

--- a/services/secret-service/src/auth-flow-manager/index.js
+++ b/services/secret-service/src/auth-flow-manager/index.js
@@ -273,7 +273,7 @@ module.exports = {
         flow, authClient, secret, tokenResponse, localMiddleware,
     }) {
         if (authClient.preprocessor) {
-            const adapter = dotProp.get(localMiddleware.preprocessor, authClient.preprocessor);
+            const adapter = dotProp.get(localMiddleware, authClient.preprocessor);
             if (!adapter) {
                 throw (new Error(`Missing preprocessor ${authClient.preprocessor}`));
             }

--- a/services/secret-service/src/dao/secret.js
+++ b/services/secret-service/src/dao/secret.js
@@ -125,7 +125,7 @@ const refresh = (secret, key, iter = 0) => new Promise(async (resolve, reject) =
                         // FIXME expired or revoked token should throw
                         _secret.value.accessToken = resp.access_token;
                         if (resp.refresh_token) {
-                            _secret.value.refresh_token = resp.refresh_token;
+                            _secret.value.refreshToken = resp.refresh_token;
                         }
                         _secret.value.expires = moment().add(resp.expires_in, 'seconds').toISOString();
                         break;

--- a/services/secret-service/src/dao/secret.js
+++ b/services/secret-service/src/dao/secret.js
@@ -87,10 +87,13 @@ const getRandom = (min, max) => Math.floor(Math.random() * (max - min) + min);
 const refresh = (secret, key, iter = 0) => new Promise(async (resolve, reject) => {
     try {
         if (!secret.lockedAt) {
+            auditLog.debug('Secret is not locked');
             if (!shouldRefreshToken(secret)) {
+                auditLog.debug('No need to refresh token. Returning existing token');
                 return resolve(secret);
             }
 
+            auditLog.debug('Getting secret from db');
             let _secret = await Secret[secret.type].findOneAndUpdate(
                 { _id: secret._id, lockedAt: { $eq: null } },
                 { lockedAt: moment() },
@@ -101,6 +104,7 @@ const refresh = (secret, key, iter = 0) => new Promise(async (resolve, reject) =
 
             if (_secret) {
                 if (shouldRefreshToken(_secret)) {
+                    auditLog.debug('shouldRefreshToken = true');
                     // decrypt _secret
                     _secret = cryptoSecret(_secret, key, DECRYPT, _secret.encryptedFields);
                     const resp = await refreshToken(_secret);
@@ -112,6 +116,7 @@ const refresh = (secret, key, iter = 0) => new Promise(async (resolve, reject) =
                             { currentError: resp, lockedAt: null },
                             { new: true },
                         );
+                        auditLog.debug('Saved error to db');
                         return reject(resp);
                     }
 
@@ -146,9 +151,11 @@ const refresh = (secret, key, iter = 0) => new Promise(async (resolve, reject) =
 
                 await _secret.save();
                 if (!decrypted) {
+                    auditLog.debug('Saving encrypted secret');
                     return resolve(_secret);
                 }
 
+                auditLog.debug('Saving encrypted secret');
                 return resolve(decrypted);
             }
         } else if (shouldAssumeRefreshTimeout(secret)) {
@@ -287,8 +294,8 @@ module.exports = {
             ...!conf.crypto.isDisabled ? {
                 $addToSet: {
                     encryptedFields: {
-                        $each: encryptedFields
-                    }
+                        $each: encryptedFields,
+                    },
                 },
             } : {},
         }, {
@@ -392,14 +399,16 @@ module.exports = {
         return modifiedSecret;
     },
 
-    async authenticateHmac({ secret, key, hmacValue, hmacAlgo, rawBody }) {
+    async authenticateHmac({
+        secret, key, hmacValue, hmacAlgo, rawBody,
+    }) {
         // Don't refresh tokens, as that would break HMAC for a refreshable token
         let _secret = secret;
         // exclude extra sensitive values
         _secret = _secret.encryptedFields && _secret.encryptedFields.length > 0
             ? cryptoSecret(_secret, key, DECRYPT, _secret.encryptedFields
                 .filter((e) => !(['refreshToken', 'inputFields'].includes(e)))) : _secret;
-        return crypto.authenticateHmac(_secret.value?.key, hmacValue, hmacAlgo, rawBody);
+        return crypto.authenticateHmac(_secret.value.key, hmacValue, hmacAlgo, rawBody);
     },
 
     cryptoSecret,


### PR DESCRIPTION
**What has changed?**
All of the changes are in the secret service
- Added Azure preprocessor to capture the preferred_username property from the JWT token
- Fixed a bug where the refresh token was being saved to refresh_token in the secret instead of refreshToken.  Because of this the new refresh_token wasn't saved to the secret when refreshing the access_token.

**Does a specific change require especially careful review?**

I have reproduced the issues and tested them with this container https://hub.docker.com/layers/blendededge/secret-service/22.2.1/images/sha256-2c5b625df3b3a4266cf7c1d35b4a9e9fafec2b4d80da15ba22849d8a932eba3e?context=explore

**What is still open or a known issue?**
None

**Release Notes**

- Added Azure preprocessor to capture the preferred_username property from the JWT token
- Fixed a bug where the refresh token was being saved to refresh_token in the secret instead of refreshToken.  Because of this the new refresh_token wasn't saved to the secret when refreshing the access_token.