### PR TITLE
Add setting for max request size to comp-repo

### DIFF
--- a/lib/component-repository/package.json
+++ b/lib/component-repository/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openintegrationhub/component-repository",
   "description": "Component repository",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "author": "Open Integration Hub",
   "engines": {
     "node": ">=12"
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "@openintegrationhub/iam-utils": "*",
-    "body-parser": "1.19.0",
     "cors": "2.8.5",
     "express": "4.17.1",
     "express-async-handler": "1.1.4",

--- a/lib/component-repository/src/config/index.js
+++ b/lib/component-repository/src/config/index.js
@@ -3,7 +3,8 @@ const configuration = {
     componentsUpdatePermission: process.env.COMPONENT_UPDATE_PERMISSION || 'components.update',
     componentDeletePermission: process.env.COMPONENT_DELETE_PERMISSION || 'components.delete',
     componentWritePermission: process.env.COMPONENT_WRITE_PERMISSION || 'components.write',
-    adminPermission: process.env.ADMIN_PERMISSION || 'all'
+    adminPermission: process.env.ADMIN_PERMISSION || 'all',
+    maxRequestBodySize: process.env.MAX_REQUEST_BODY_SIZE || '100kb'
 };
 
 module.exports = configuration;

--- a/lib/component-repository/src/routes/components/index.js
+++ b/lib/component-repository/src/routes/components/index.js
@@ -1,9 +1,9 @@
-const { Router } = require('express');
+const express = require('express');
 const asyncHandler = require('express-async-handler');
-const bodyParser = require('body-parser').json();
+const config = require('../../config');
+const bodyParser = express.json({limit:config.maxRequestBodySize});
 const { parsePagedQuery } = require('../../middleware');
 
-const config = require('../../config');
 const Component = require('../../models/Component');
 
 async function loadComponent(req, res, next) {
@@ -88,7 +88,7 @@ module.exports = ({ iam }) => {
     const GlobalConnectorRestartAll = asyncHandler(require('./GlobalRestartAll'));
     const Enrich = asyncHandler(require('./Enrich'));
 
-    const router = Router();
+    const router = express.Router();
     router.use(asyncHandler(iam.middleware));
     router.use((req, res, next) => {
         req.logger.trace({user: req.user}, 'Resolved IAM user');
@@ -104,7 +104,7 @@ module.exports = ({ iam }) => {
     router.post('/global/:id/start', can(config.adminPermission), loadComp, GlobalConnectorStart);
     router.post('/global/:id/stop', can(config.adminPermission), loadComp, GlobalConnectorStop);
 
-    router.post('/global/restart/all', can(config.adminPermission), GlobalConnectorRestartAll); 
+    router.post('/global/restart/all', can(config.adminPermission), GlobalConnectorRestartAll);
 
     router.patch('/enrich/:id', can(config.componentsUpdatePermission), loadComp, canWrite, Enrich);
 

--- a/lib/component-repository/src/routes/virtual-components/index.js
+++ b/lib/component-repository/src/routes/virtual-components/index.js
@@ -1,8 +1,8 @@
 const express = require('express');
 const asyncHandler = require('express-async-handler');
-const bodyParser = express.json();
-
 const config = require('../../config');
+const bodyParser = express.json({limit:config.maxRequestBodySize});
+
 const VirtualComponent = require('../../models/VirtualComponent');
 
 const isValidVirtualComponent = (virtualComponent, user) => {

--- a/services/component-repository/package.json
+++ b/services/component-repository/package.json
@@ -2,7 +2,7 @@
   "name": "component-repository",
   "description": "Component repository",
   "private": true,
-  "version": "1.6.2",
+  "version": "1.7.0",
   "author": "Open Integration Hub",
   "engines": {
     "node": ">=12"


### PR DESCRIPTION
In order to handle large requests passing function and schema data to components, it is often necessary to increase the size of the request body. This PR adds a MAX_REQUEST_BODY_SIZE variable which can increase from the express default 100kb.