### PR TITLE
remove length restriction on the description field of component version

### DIFF
--- a/lib/component-repository/src/models/ComponentVersion.js
+++ b/lib/component-repository/src/models/ComponentVersion.js
@@ -14,7 +14,6 @@ const func = new Schema(
     },
     description: {
       type: String,
-      maxLength: 300,
     },
     function: {
       type: String,


### PR DESCRIPTION
**What has changed?**

- Removed maxLength: 300 from the description field of component versions
