### PR TITLE
Update Mongoose for Mongo 6.x

### DIFF
--- a/dev-tools/docker-compose/package.json
+++ b/dev-tools/docker-compose/package.json
@@ -1,13 +1,13 @@
 {
   "name": "dt-docker-compose",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
     "dotenv": "10.0.0",
     "faker": "5.5.3",
     "form-data": "4.0.0",
-    "mongoose": "6.2.1",
+    "mongoose": "6.10.3",
     "node-fetch": "2.6.1",
     "yaml": "1.10.0",
     "lodash": "4.17.21",

--- a/dev-tools/minikube/setup.sh
+++ b/dev-tools/minikube/setup.sh
@@ -380,7 +380,7 @@ function sourceInstall {
     for service in "${from_source[@]}"
     do
         colorEcho 34 "Installing deps for $service"
-        npm install --prefix $rootdir -w "services/$service" 
+        npm install --prefix $rootdir -w "$service" 
     done
 }
 
@@ -981,12 +981,19 @@ createDevPrivateComponent
 
 waitForServiceStatus http://flow-repository.example.com/flows 401
 
+echo "Flow Ready"
 createDevSimpleFlow
+echo "Created Simple Flow"
 createDevWebhookFlow
+echo "Created Webhook Flow"
 createDevGlobalConsecutiveFlow
+echo "created global consecutive flow"
 createDevConsecutiveFlow
+echo "created consecutive local flow"
 createDevConcurrentFlow
+echo "created concurrent flow"
 createDevGlobalFlow
+echo "created global flow"
 
 ###
 ### 12. Point to web ui if ready

--- a/lib/component-repository/package.json
+++ b/lib/component-repository/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openintegrationhub/component-repository",
   "description": "Component repository",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "author": "Open Integration Hub",
   "engines": {
     "node": ">=12"
@@ -17,7 +17,7 @@
     "express": "4.17.1",
     "express-async-handler": "1.1.4",
     "lodash": "4.17.21",
-    "mongoose": "6.2.1",
+    "mongoose": "6.10.3",
     "node-fetch": "2.6.1",
     "swagger-ui-express": "4.0.2"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
 				"faker": "5.5.3",
 				"form-data": "4.0.0",
 				"lodash": "4.17.21",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"node-fetch": "2.6.1",
 				"uuid": "8.3.2",
 				"yaml": "1.10.0"
@@ -454,15 +454,14 @@
 		},
 		"lib/component-repository": {
 			"name": "@openintegrationhub/component-repository",
-			"version": "0.5.2",
+			"version": "0.6.1",
 			"dependencies": {
 				"@openintegrationhub/iam-utils": "*",
-				"body-parser": "1.19.0",
 				"cors": "2.8.5",
 				"express": "4.17.1",
 				"express-async-handler": "1.1.4",
 				"lodash": "4.17.21",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"node-fetch": "2.6.1",
 				"swagger-ui-express": "4.0.2"
 			},
@@ -1858,6 +1857,1070 @@
 			"license": "MIT",
 			"bin": {
 				"uuid": "bin/uuid"
+			}
+		},
+		"node_modules/@aws-crypto/ie11-detection": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+			"integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"optional": true
+		},
+		"node_modules/@aws-crypto/sha256-browser": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+			"integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+			"optional": true,
+			"dependencies": {
+				"@aws-crypto/ie11-detection": "^3.0.0",
+				"@aws-crypto/sha256-js": "^3.0.0",
+				"@aws-crypto/supports-web-crypto": "^3.0.0",
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@aws-sdk/util-utf8-browser": "^3.0.0",
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"optional": true
+		},
+		"node_modules/@aws-crypto/sha256-js": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+			"integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+			"optional": true,
+			"dependencies": {
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"optional": true
+		},
+		"node_modules/@aws-crypto/supports-web-crypto": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+			"integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"optional": true
+		},
+		"node_modules/@aws-crypto/util": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+			"integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-utf8-browser": "^3.0.0",
+				"tslib": "^1.11.1"
+			}
+		},
+		"node_modules/@aws-crypto/util/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"optional": true
+		},
+		"node_modules/@aws-sdk/abort-controller": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.292.0.tgz",
+			"integrity": "sha512-lf+OPptL01kvryIJy7+dvFux5KbJ6OTwLPPEekVKZ2AfEvwcVtOZWFUhyw3PJCBTVncjKB1Kjl3V/eTS3YuPXQ==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-cognito-identity": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.292.0.tgz",
+			"integrity": "sha512-xDdpB5xhfN31rXgjC84WoneMX7wObMJkyb5Vat838XMKWKAZLNZmt/3p6OcAmkCwupL8LqS2oSG0Bp+uJOjyGg==",
+			"optional": true,
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/client-sts": "3.292.0",
+				"@aws-sdk/config-resolver": "3.292.0",
+				"@aws-sdk/credential-provider-node": "3.292.0",
+				"@aws-sdk/fetch-http-handler": "3.292.0",
+				"@aws-sdk/hash-node": "3.292.0",
+				"@aws-sdk/invalid-dependency": "3.292.0",
+				"@aws-sdk/middleware-content-length": "3.292.0",
+				"@aws-sdk/middleware-endpoint": "3.292.0",
+				"@aws-sdk/middleware-host-header": "3.292.0",
+				"@aws-sdk/middleware-logger": "3.292.0",
+				"@aws-sdk/middleware-recursion-detection": "3.292.0",
+				"@aws-sdk/middleware-retry": "3.292.0",
+				"@aws-sdk/middleware-serde": "3.292.0",
+				"@aws-sdk/middleware-signing": "3.292.0",
+				"@aws-sdk/middleware-stack": "3.292.0",
+				"@aws-sdk/middleware-user-agent": "3.292.0",
+				"@aws-sdk/node-config-provider": "3.292.0",
+				"@aws-sdk/node-http-handler": "3.292.0",
+				"@aws-sdk/protocol-http": "3.292.0",
+				"@aws-sdk/smithy-client": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"@aws-sdk/url-parser": "3.292.0",
+				"@aws-sdk/util-base64": "3.292.0",
+				"@aws-sdk/util-body-length-browser": "3.292.0",
+				"@aws-sdk/util-body-length-node": "3.292.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.292.0",
+				"@aws-sdk/util-defaults-mode-node": "3.292.0",
+				"@aws-sdk/util-endpoints": "3.292.0",
+				"@aws-sdk/util-retry": "3.292.0",
+				"@aws-sdk/util-user-agent-browser": "3.292.0",
+				"@aws-sdk/util-user-agent-node": "3.292.0",
+				"@aws-sdk/util-utf8": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sso": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.292.0.tgz",
+			"integrity": "sha512-DzBBa72TTgfTllvTbD/7KcRY8bo5ExUv8gHJaedrE7mlZUn/2msk9S41rf+Rcwb0bf7k14Y36aRVwoXwQCKPLg==",
+			"optional": true,
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/config-resolver": "3.292.0",
+				"@aws-sdk/fetch-http-handler": "3.292.0",
+				"@aws-sdk/hash-node": "3.292.0",
+				"@aws-sdk/invalid-dependency": "3.292.0",
+				"@aws-sdk/middleware-content-length": "3.292.0",
+				"@aws-sdk/middleware-endpoint": "3.292.0",
+				"@aws-sdk/middleware-host-header": "3.292.0",
+				"@aws-sdk/middleware-logger": "3.292.0",
+				"@aws-sdk/middleware-recursion-detection": "3.292.0",
+				"@aws-sdk/middleware-retry": "3.292.0",
+				"@aws-sdk/middleware-serde": "3.292.0",
+				"@aws-sdk/middleware-stack": "3.292.0",
+				"@aws-sdk/middleware-user-agent": "3.292.0",
+				"@aws-sdk/node-config-provider": "3.292.0",
+				"@aws-sdk/node-http-handler": "3.292.0",
+				"@aws-sdk/protocol-http": "3.292.0",
+				"@aws-sdk/smithy-client": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"@aws-sdk/url-parser": "3.292.0",
+				"@aws-sdk/util-base64": "3.292.0",
+				"@aws-sdk/util-body-length-browser": "3.292.0",
+				"@aws-sdk/util-body-length-node": "3.292.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.292.0",
+				"@aws-sdk/util-defaults-mode-node": "3.292.0",
+				"@aws-sdk/util-endpoints": "3.292.0",
+				"@aws-sdk/util-retry": "3.292.0",
+				"@aws-sdk/util-user-agent-browser": "3.292.0",
+				"@aws-sdk/util-user-agent-node": "3.292.0",
+				"@aws-sdk/util-utf8": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sso-oidc": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.292.0.tgz",
+			"integrity": "sha512-KANoinZDvWwCXKrx92V0i8ItovKwW94Ep4vLY+D7ZmuV8IACK0XcIR9HF8eMR4Zqy7DSBAGdvvd318Qy2v1f2Q==",
+			"optional": true,
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/config-resolver": "3.292.0",
+				"@aws-sdk/fetch-http-handler": "3.292.0",
+				"@aws-sdk/hash-node": "3.292.0",
+				"@aws-sdk/invalid-dependency": "3.292.0",
+				"@aws-sdk/middleware-content-length": "3.292.0",
+				"@aws-sdk/middleware-endpoint": "3.292.0",
+				"@aws-sdk/middleware-host-header": "3.292.0",
+				"@aws-sdk/middleware-logger": "3.292.0",
+				"@aws-sdk/middleware-recursion-detection": "3.292.0",
+				"@aws-sdk/middleware-retry": "3.292.0",
+				"@aws-sdk/middleware-serde": "3.292.0",
+				"@aws-sdk/middleware-stack": "3.292.0",
+				"@aws-sdk/middleware-user-agent": "3.292.0",
+				"@aws-sdk/node-config-provider": "3.292.0",
+				"@aws-sdk/node-http-handler": "3.292.0",
+				"@aws-sdk/protocol-http": "3.292.0",
+				"@aws-sdk/smithy-client": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"@aws-sdk/url-parser": "3.292.0",
+				"@aws-sdk/util-base64": "3.292.0",
+				"@aws-sdk/util-body-length-browser": "3.292.0",
+				"@aws-sdk/util-body-length-node": "3.292.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.292.0",
+				"@aws-sdk/util-defaults-mode-node": "3.292.0",
+				"@aws-sdk/util-endpoints": "3.292.0",
+				"@aws-sdk/util-retry": "3.292.0",
+				"@aws-sdk/util-user-agent-browser": "3.292.0",
+				"@aws-sdk/util-user-agent-node": "3.292.0",
+				"@aws-sdk/util-utf8": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-sts": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.292.0.tgz",
+			"integrity": "sha512-t9Q0+iT8E1QAARq7aUHdF5KwgXrdW1yl4lsnkmVcLJKypyhnXTVJ68qldV6rBDSFswGqT0SBQBzcAj6vPNlOFQ==",
+			"optional": true,
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/config-resolver": "3.292.0",
+				"@aws-sdk/credential-provider-node": "3.292.0",
+				"@aws-sdk/fetch-http-handler": "3.292.0",
+				"@aws-sdk/hash-node": "3.292.0",
+				"@aws-sdk/invalid-dependency": "3.292.0",
+				"@aws-sdk/middleware-content-length": "3.292.0",
+				"@aws-sdk/middleware-endpoint": "3.292.0",
+				"@aws-sdk/middleware-host-header": "3.292.0",
+				"@aws-sdk/middleware-logger": "3.292.0",
+				"@aws-sdk/middleware-recursion-detection": "3.292.0",
+				"@aws-sdk/middleware-retry": "3.292.0",
+				"@aws-sdk/middleware-sdk-sts": "3.292.0",
+				"@aws-sdk/middleware-serde": "3.292.0",
+				"@aws-sdk/middleware-signing": "3.292.0",
+				"@aws-sdk/middleware-stack": "3.292.0",
+				"@aws-sdk/middleware-user-agent": "3.292.0",
+				"@aws-sdk/node-config-provider": "3.292.0",
+				"@aws-sdk/node-http-handler": "3.292.0",
+				"@aws-sdk/protocol-http": "3.292.0",
+				"@aws-sdk/smithy-client": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"@aws-sdk/url-parser": "3.292.0",
+				"@aws-sdk/util-base64": "3.292.0",
+				"@aws-sdk/util-body-length-browser": "3.292.0",
+				"@aws-sdk/util-body-length-node": "3.292.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.292.0",
+				"@aws-sdk/util-defaults-mode-node": "3.292.0",
+				"@aws-sdk/util-endpoints": "3.292.0",
+				"@aws-sdk/util-retry": "3.292.0",
+				"@aws-sdk/util-user-agent-browser": "3.292.0",
+				"@aws-sdk/util-user-agent-node": "3.292.0",
+				"@aws-sdk/util-utf8": "3.292.0",
+				"fast-xml-parser": "4.1.2",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/config-resolver": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.292.0.tgz",
+			"integrity": "sha512-cB3twnNR7vYvlt2jvw8VlA1+iv/tVzl+/S39MKqw2tepU+AbJAM0EHwb/dkf1OKSmlrnANXhshx80MHF9zL4mA==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/signature-v4": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"@aws-sdk/util-config-provider": "3.292.0",
+				"@aws-sdk/util-middleware": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-cognito-identity": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.292.0.tgz",
+			"integrity": "sha512-UoAyoS1Dx2yVT/LJUnH2LBojyb0go9xJWnO6hhQFeU8iFCvM/GbNA/v1daf6V7FBbujfYcK3pVP66BlYXX6I5w==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/client-cognito-identity": "3.292.0",
+				"@aws-sdk/property-provider": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.292.0.tgz",
+			"integrity": "sha512-YbafSG0ZEKE2969CJWVtUhh3hfOeLPecFVoXOtegCyAJgY5Ghtu4TsVhL4DgiGAgOC30ojAmUVQEXzd7xJF5xA==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/property-provider": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-imds": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.292.0.tgz",
+			"integrity": "sha512-W/peOgDSRYulgzFpUhvgi1pCm6piBz6xrVN17N4QOy+3NHBXRVMVzYk6ct2qpLPgJUSEZkcpP+Gds+bBm8ed1A==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/node-config-provider": "3.292.0",
+				"@aws-sdk/property-provider": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"@aws-sdk/url-parser": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.292.0.tgz",
+			"integrity": "sha512-gTXSGjx3Q+KY8Zz/XHTDWOBx9UWtL3s8tTdpQOdaMqqm0xIK5X4KDud3L/huPpZYm0a7rNAML8l1mU56FFnBVw==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "3.292.0",
+				"@aws-sdk/credential-provider-imds": "3.292.0",
+				"@aws-sdk/credential-provider-process": "3.292.0",
+				"@aws-sdk/credential-provider-sso": "3.292.0",
+				"@aws-sdk/credential-provider-web-identity": "3.292.0",
+				"@aws-sdk/property-provider": "3.292.0",
+				"@aws-sdk/shared-ini-file-loader": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.292.0.tgz",
+			"integrity": "sha512-85LQIeSGSQtbrgqEYmCcUnehBmTKt8bbn7mN9RxbtCDnZVgEagJCid7o9+fYQXZ5IjXaHLUApoLsv6ytEj4ITA==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "3.292.0",
+				"@aws-sdk/credential-provider-imds": "3.292.0",
+				"@aws-sdk/credential-provider-ini": "3.292.0",
+				"@aws-sdk/credential-provider-process": "3.292.0",
+				"@aws-sdk/credential-provider-sso": "3.292.0",
+				"@aws-sdk/credential-provider-web-identity": "3.292.0",
+				"@aws-sdk/property-provider": "3.292.0",
+				"@aws-sdk/shared-ini-file-loader": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.292.0.tgz",
+			"integrity": "sha512-CFVXuMuUvg/a4tknzRikEDwZBnKlHs1LZCpTXIGjBdUTdosoi4WNzDLzGp93ZRTtcgFz+4wirz2f7P3lC0NrQw==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/property-provider": "3.292.0",
+				"@aws-sdk/shared-ini-file-loader": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.292.0.tgz",
+			"integrity": "sha512-+jrhi0oZc9dMtbRsqi+lkqIheCb8QlsRJSEKDa3nUlyxaOkzRKR9Yf5Jtpqooa0ichFhMVZTD9oXPFrlGROIEQ==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/client-sso": "3.292.0",
+				"@aws-sdk/property-provider": "3.292.0",
+				"@aws-sdk/shared-ini-file-loader": "3.292.0",
+				"@aws-sdk/token-providers": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.292.0.tgz",
+			"integrity": "sha512-4DbtIEM9gGVfqYlMdYXg3XY+vBhemjB1zXIequottW8loLYM8Vuz4/uGxxKNze6evVVzowsA0wKrYclE1aj/Rg==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/property-provider": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-providers": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.292.0.tgz",
+			"integrity": "sha512-0PjOmi1JzbfaW+4fKxIzxviiZ4FZiW/0MT6ba0hMVldoXQYpLkmTJx1Hfsvw5o2eqCVJ5kLYEIjLnmrKKR3WUQ==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/client-cognito-identity": "3.292.0",
+				"@aws-sdk/client-sso": "3.292.0",
+				"@aws-sdk/client-sts": "3.292.0",
+				"@aws-sdk/credential-provider-cognito-identity": "3.292.0",
+				"@aws-sdk/credential-provider-env": "3.292.0",
+				"@aws-sdk/credential-provider-imds": "3.292.0",
+				"@aws-sdk/credential-provider-ini": "3.292.0",
+				"@aws-sdk/credential-provider-node": "3.292.0",
+				"@aws-sdk/credential-provider-process": "3.292.0",
+				"@aws-sdk/credential-provider-sso": "3.292.0",
+				"@aws-sdk/credential-provider-web-identity": "3.292.0",
+				"@aws-sdk/property-provider": "3.292.0",
+				"@aws-sdk/shared-ini-file-loader": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/fetch-http-handler": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.292.0.tgz",
+			"integrity": "sha512-zh3bhUJbL8RSa39ZKDcy+AghtUkIP8LwcNlwRIoxMQh3Row4D1s4fCq0KZCx98NJBEXoiTLyTQlZxxI//BOb1Q==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/protocol-http": "3.292.0",
+				"@aws-sdk/querystring-builder": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"@aws-sdk/util-base64": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"node_modules/@aws-sdk/hash-node": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.292.0.tgz",
+			"integrity": "sha512-1yLxmIsvE+eK36JXEgEIouTITdykQLVhsA5Oai//Lar6Ddgu1sFpLDbdkMtKbrh4I0jLN9RacNCkeVQjZPTCCQ==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/types": "3.292.0",
+				"@aws-sdk/util-buffer-from": "3.292.0",
+				"@aws-sdk/util-utf8": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/invalid-dependency": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.292.0.tgz",
+			"integrity": "sha512-39OUV78CD3TmEbjhpt+V+Fk4wAGWhixqHxDSN8+4WL0uB4Fl7k5m3Z9hNY78AttHQSl2twR7WtLztnXPAFsriw==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"node_modules/@aws-sdk/is-array-buffer": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.292.0.tgz",
+			"integrity": "sha512-kW/G5T/fzI0sJH5foZG6XJiNCevXqKLxV50qIT4B1pMuw7regd4ALIy0HwSqj1nnn9mSbRWBfmby0jWCJsMcwg==",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-content-length": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.292.0.tgz",
+			"integrity": "sha512-2gMWzQus5mj14menolpPDbYBeaOYcj7KNFZOjTjjI3iQ0KqyetG6XasirNrcJ/8QX1BRmpTol8Xjp2Ue3Gbzwg==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/protocol-http": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-endpoint": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.292.0.tgz",
+			"integrity": "sha512-cPMkiSxpZGG6tYlW4OS+ucS6r43f9ddX9kcUoemJCY10MOuogdPjulCAjE0HTs2PLKSOrrG4CTP4Q4wWDrH4Bw==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/middleware-serde": "3.292.0",
+				"@aws-sdk/protocol-http": "3.292.0",
+				"@aws-sdk/signature-v4": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"@aws-sdk/url-parser": "3.292.0",
+				"@aws-sdk/util-config-provider": "3.292.0",
+				"@aws-sdk/util-middleware": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.292.0.tgz",
+			"integrity": "sha512-mHuCWe3Yg2S5YZ7mB7sKU6C97XspfqrimWjMW9pfV2usAvLA3R0HrB03jpR5vpZ3P4q7HB6wK3S6CjYMGGRNag==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/protocol-http": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.292.0.tgz",
+			"integrity": "sha512-yZNY1XYmG3NG+uonET7jzKXNiwu61xm/ZZ6i/l51SusuaYN+qQtTAhOFsieQqTehF9kP4FzbsWgPDwD8ZZX9lw==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.292.0.tgz",
+			"integrity": "sha512-kA3VZpPko0Zqd7CYPTKAxhjEv0HJqFu2054L04dde1JLr43ro+2MTdX7vsHzeAFUVRphqatFFofCumvXmU6Mig==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/protocol-http": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-retry": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.292.0.tgz",
+			"integrity": "sha512-wUuXwiwMwFNMTgc9oFeUHkgpF56EfLJl/EtRn2376k9sFd7JoFu3zTo3VTGROLH/88r20A01TOr9g/cFjXgCJQ==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/protocol-http": "3.292.0",
+				"@aws-sdk/service-error-classification": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"@aws-sdk/util-middleware": "3.292.0",
+				"@aws-sdk/util-retry": "3.292.0",
+				"tslib": "^2.3.1",
+				"uuid": "^8.3.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-sdk-sts": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.292.0.tgz",
+			"integrity": "sha512-GN5ZHEqXZqDi+HkVbaXRX9HaW/vA5rikYpWKYsmxTUZ7fB7ijvEO3co3lleJv2C+iGYRtUIHC4wYNB5xgoTCxg==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/middleware-signing": "3.292.0",
+				"@aws-sdk/property-provider": "3.292.0",
+				"@aws-sdk/protocol-http": "3.292.0",
+				"@aws-sdk/signature-v4": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-serde": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.292.0.tgz",
+			"integrity": "sha512-6hN9mTQwSvV8EcGvtXbS/MpK7WMCokUku5Wu7X24UwCNMVkoRHLIkYcxHcvBTwttuOU0d8hph1/lIX4dkLwkQw==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-signing": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.292.0.tgz",
+			"integrity": "sha512-GVfoSjDjEQ4TaO6x9MffyP3uRV+2KcS5FtexLCYOM9pJcnE9tqq9FJOrZ1xl1g+YjUVKxo4x8lu3tpEtIb17qg==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/property-provider": "3.292.0",
+				"@aws-sdk/protocol-http": "3.292.0",
+				"@aws-sdk/signature-v4": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"@aws-sdk/util-middleware": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-stack": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.292.0.tgz",
+			"integrity": "sha512-WdQpRkuMysrEwrkByCM1qCn2PPpFGGQ2iXqaFha5RzCdZDlxJni9cVNb6HzWUcgjLEYVTXCmOR9Wxm3CNW44Qg==",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.292.0.tgz",
+			"integrity": "sha512-PvGMfPwfW1nq9fzWKIIS6USjY70FfdmiZhFL/TyoaTp8gV/Y1+Le8i6E1LegDbnbE/LS5IBuNgUzdserYcfbOQ==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/protocol-http": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/node-config-provider": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.292.0.tgz",
+			"integrity": "sha512-S3NnC9dQ5GIbJYSDIldZb4zdpCOEua1tM7bjYL3VS5uqCEM93kIi/o/UkIUveMp/eqTS2LJa5HjNIz5Te6je0A==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/property-provider": "3.292.0",
+				"@aws-sdk/shared-ini-file-loader": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/node-http-handler": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.292.0.tgz",
+			"integrity": "sha512-L/E3UDSwXLXjt1XWWh0RBD55F+aZI1AEdPwdES9i1PjnZLyuxuDhEDptVibNN56+I9/4Q3SbmuVRVlOD0uzBag==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/abort-controller": "3.292.0",
+				"@aws-sdk/protocol-http": "3.292.0",
+				"@aws-sdk/querystring-builder": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/property-provider": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.292.0.tgz",
+			"integrity": "sha512-dHArSvsiqhno/g55N815gXmAMrmN8DP7OeFNqJ4wJG42xsF2PFN3DAsjIuHuXMwu+7A3R1LHqIpvv0hA9KeoJQ==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/protocol-http": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.292.0.tgz",
+			"integrity": "sha512-NLi4fq3k41aXIh1I97yX0JTy+3p6aW1NdwFwdMa674z86QNfb4SfRQRZBQe9wEnAZ/eWHVnlKIuII+U1URk/Kg==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/querystring-builder": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.292.0.tgz",
+			"integrity": "sha512-XElIFJaReIm24eEvBtV2dOtZvcm3gXsGu/ftG8MLJKbKXFKpAP1q+K6En0Bs7/T88voKghKdKpKT+eZUWgTqlg==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/types": "3.292.0",
+				"@aws-sdk/util-uri-escape": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/querystring-parser": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.292.0.tgz",
+			"integrity": "sha512-iTYpYo7a8X9RxiPbjjewIpm6XQPx2EOcF1dWCPRII9EFlmZ4bwnX+PDI36fIo9oVs8TIKXmwNGODU9nsg7CSAw==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/service-error-classification": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.292.0.tgz",
+			"integrity": "sha512-X1k3sixCeC45XSNHBe+kRBQBwPDyTFtFITb8O5Qw4dS9XWGhrUJT4CX0qE5aj8qP3F9U5nRizs9c2mBVVP0Caw==",
+			"optional": true,
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/shared-ini-file-loader": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.292.0.tgz",
+			"integrity": "sha512-Av2TTYg1Jig2kbkD56ybiqZJB6vVrYjv1W5UQwY/q3nA/T2mcrgQ20ByCOt5Bv9VvY7FSgC+znj+L4a7RLGmBg==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/signature-v4": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.292.0.tgz",
+			"integrity": "sha512-+rw47VY5mvBecn13tDQTl1ipGWg5tE63faWgmZe68HoBL87ZiDzsd7bUKOvjfW21iMgWlwAppkaNNQayYRb2zg==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/is-array-buffer": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"@aws-sdk/util-hex-encoding": "3.292.0",
+				"@aws-sdk/util-middleware": "3.292.0",
+				"@aws-sdk/util-uri-escape": "3.292.0",
+				"@aws-sdk/util-utf8": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/smithy-client": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.292.0.tgz",
+			"integrity": "sha512-S8PKzjPkZ6SXYZuZiU787dMsvQ0d/LFEhw2OI4Oe2An9Fc2IwJ2FYukyHoQJOV2tV0DiuMebPo7eMyQyjKElvA==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/middleware-stack": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/token-providers": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.292.0.tgz",
+			"integrity": "sha512-RJ+fQp/SsMnuH+WrTWaLR2Kq1b/fQdSq4zDwtauultSEBQknd7RAgjQ4JBVaIwR66vJjQPa3MXYfgja/oONT+w==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/client-sso-oidc": "3.292.0",
+				"@aws-sdk/property-provider": "3.292.0",
+				"@aws-sdk/shared-ini-file-loader": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/types": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.292.0.tgz",
+			"integrity": "sha512-1teYAY2M73UXZxMAxqZxVS2qwXjQh0OWtt7qyLfha0TtIk/fZ1hRwFgxbDCHUFcdNBSOSbKH/ESor90KROXLCQ==",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/url-parser": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.292.0.tgz",
+			"integrity": "sha512-NZeAuZCk1x6TIiWuRfbOU6wHPBhf0ly2qOHzWut4BCH+b4RrDmFF8EmXcH1auEfGhE7yRyR6XqIN0t3S+hYACA==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/querystring-parser": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"node_modules/@aws-sdk/util-base64": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.292.0.tgz",
+			"integrity": "sha512-zjNCwNdy617yFvEjZorepNWXB2sQCVfsShCwFy/kIQ5iW5tT2jQKaqc0K77diU9atkooxw9p1W9m9sOgrkOFNw==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/util-buffer-from": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-body-length-browser": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.292.0.tgz",
+			"integrity": "sha512-Wd/BM+JsMiKvKs/bN3z6TredVEHh2pKudGfg3CSjTRpqFpOG903KDfyHBD42yg5PuCHoHoewJvTPKwgn7/vhaw==",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.3.1"
+			}
+		},
+		"node_modules/@aws-sdk/util-body-length-node": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.292.0.tgz",
+			"integrity": "sha512-BBgipZ2P6RhogWE/qj0oqpdlyd3iSBYmb+aD/TBXwB2lA/X8A99GxweBd/kp06AmcJRoMS9WIXgbWkiiBlRlSA==",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-buffer-from": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.292.0.tgz",
+			"integrity": "sha512-RxNZjLoXNxHconH9TYsk5RaEBjSgTtozHeyIdacaHPj5vlQKi4hgL2hIfKeeNiAfQEVjaUFF29lv81xpNMzVMQ==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/is-array-buffer": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-config-provider": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.292.0.tgz",
+			"integrity": "sha512-t3noYll6bPRSxeeNNEkC5czVjAiTPcsq00OwfJ2xyUqmquhLEfLwoJKmrT1uP7DjIEXdUtfoIQ2jWiIVm/oO5A==",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-defaults-mode-browser": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.292.0.tgz",
+			"integrity": "sha512-7+zVUlMGfa8/KT++9humHo6IDxTnxMCmWUj5jVNlkpk6h7Ecmppf7aXotviyVIA43lhtz0p2AErs0N0ekEUK+w==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/property-provider": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-defaults-mode-node": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.292.0.tgz",
+			"integrity": "sha512-SSIw85eF4BVs0fOJRyshT+R3b/UmBPhiVKCUZm2rq6+lIGkDPiSwQU3d/80AhXtiL5SFT/IzAKKgQd8qMa7q3A==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/config-resolver": "3.292.0",
+				"@aws-sdk/credential-provider-imds": "3.292.0",
+				"@aws-sdk/node-config-provider": "3.292.0",
+				"@aws-sdk/property-provider": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.292.0.tgz",
+			"integrity": "sha512-CvNES1YaickVE8Iu2EP4ywdiCNy8thRnyXdx7v1d39NLeTQuMWJyM/cazWQIBv0WPYOrAnjsWb5Nw05GwpwSdA==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-hex-encoding": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.292.0.tgz",
+			"integrity": "sha512-qBd5KFIUywQ3qSSbj814S2srk0vfv8A6QMI+Obs1y2LHZFdQN5zViptI4UhXhKOHe+NnrHWxSuLC/LMH6q3SmA==",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-locate-window": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.292.0.tgz",
+			"integrity": "sha512-6xnFJXZI9pKw5lQCDvuWA5PnOaUtNRKWwdxvGkkLx5orboFaoVMS6zowjSQxwVNRjW82u6dYNkhmj9mZ8VSjWg==",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-middleware": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.292.0.tgz",
+			"integrity": "sha512-KjhS7flfoBKDxbiBZjLjMvEizXgjfQb7GQEItgzGoI9rfGCmZtvqCcqQQoIlxb8bIzGRggAUHtBGWnlLbpb+GQ==",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-retry": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.292.0.tgz",
+			"integrity": "sha512-JEHyF7MpVeRF5uR4LDYgpOKcFpOPiAj8TqN46SVOQQcL1K+V7cSr7O7N7J6MwJaN9XOzAcBadeIupMm7/BFbgw==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/service-error-classification": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-uri-escape": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.292.0.tgz",
+			"integrity": "sha512-hOQtUMQ4VcQ9iwKz50AoCp1XBD5gJ9nly/gJZccAM7zSA5mOO8RRKkbdonqquVHxrO0CnYgiFeCh3V35GFecUw==",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.292.0.tgz",
+			"integrity": "sha512-dld+lpC3QdmTQHdBWJ0WFDkXDSrJgfz03q6mQ8+7H+BC12ZhT0I0g9iuvUjolqy7QR00OxOy47Y9FVhq8EC0Gg==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/types": "3.292.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.292.0.tgz",
+			"integrity": "sha512-f+NfIMal5E61MDc5WGhUEoicr7b1eNNhA+GgVdSB/Hg5fYhEZvFK9RZizH5rrtsLjjgcr9nPYSR7/nDKCJLumw==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/node-config-provider": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"aws-crt": ">=1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"aws-crt": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-sdk/util-utf8": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.292.0.tgz",
+			"integrity": "sha512-FPkj+Z59/DQWvoVu2wFaRncc3KVwe/pgK3MfVb0Lx+Ibey5KUx+sNpJmYcVYHUAe/Nv/JeIpOtYuC96IXOnI6w==",
+			"optional": true,
+			"dependencies": {
+				"@aws-sdk/util-buffer-from": "3.292.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-utf8-browser": {
+			"version": "3.259.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+			"integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.3.1"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -7808,6 +8871,12 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/bowser": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+			"integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+			"optional": true
+		},
 		"node_modules/boxen": {
 			"version": "4.2.0",
 			"dev": true,
@@ -7917,9 +8986,9 @@
 			}
 		},
 		"node_modules/bson": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/bson/-/bson-4.6.1.tgz",
-			"integrity": "sha512-I1LQ7Hz5zgwR4QquilLNZwbhPw0Apx7i7X9kGMBTsqPdml/03Q9NBtD9nt/19ahjlphktQImrnderxqpzeVDjw==",
+			"version": "4.7.2",
+			"resolved": "https://registry.npmjs.org/bson/-/bson-4.7.2.tgz",
+			"integrity": "sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==",
 			"dependencies": {
 				"buffer": "^5.6.0"
 			},
@@ -10161,6 +11230,7 @@
 		},
 		"node_modules/denque": {
 			"version": "2.0.1",
+			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=0.10"
@@ -12240,6 +13310,22 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/fast-xml-parser": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+			"integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+			"optional": true,
+			"dependencies": {
+				"strnum": "^1.0.5"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			},
+			"funding": {
+				"type": "paypal",
+				"url": "https://paypal.me/naturalintelligence"
+			}
+		},
 		"node_modules/fastq": {
 			"version": "1.13.0",
 			"dev": true,
@@ -14284,7 +15370,8 @@
 		"node_modules/ip": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+			"dev": true
 		},
 		"node_modules/ipaddr.js": {
 			"version": "1.9.1",
@@ -16810,9 +17897,12 @@
 			}
 		},
 		"node_modules/kareem": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.3.tgz",
-			"integrity": "sha512-uESCXM2KdtOQ8LOvKyTUXEeg0MkYp4wGglTIpGcYHvjJcS5sn2Wkfrfit8m4xSbaNDAw2KdI9elgkOxZbrFYbg=="
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
+			"integrity": "sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA==",
+			"engines": {
+				"node": ">=12.0.0"
+			}
 		},
 		"node_modules/kerberos": {
 			"version": "1.1.7",
@@ -18152,9 +19242,9 @@
 			}
 		},
 		"node_modules/mongodb-connection-string-url": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.4.2.tgz",
-			"integrity": "sha512-mZUXF6nUzRWk5J3h41MsPv13ukWlH4jOMSk6astVeoZ1EbdTJyF5I3wxKkvqBAOoVtzLgyEYUvDjrGdcPlKjAw==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+			"integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
 			"dependencies": {
 				"@types/whatwg-url": "^8.2.1",
 				"whatwg-url": "^11.0.0"
@@ -18418,17 +19508,17 @@
 			}
 		},
 		"node_modules/mongoose": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.2.1.tgz",
-			"integrity": "sha512-VxY1wvlc4uBQKyKNVDoEkTU3/ayFOD//qVXYP+sFyvTRbAj9/M53UWTERd84pWogs2TqAC6DTvZbxCs2LoOd3Q==",
+			"version": "6.10.3",
+			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.10.3.tgz",
+			"integrity": "sha512-fZ3pIlQn7lM632r1l4qiU58lKrJ+FufKVG8TNeRXSChAeu9alCl5KoQ9bLw4jnQNYevSq9o+sqZmFDHP+EVW3g==",
 			"dependencies": {
-				"bson": "^4.2.2",
-				"kareem": "2.3.3",
-				"mongodb": "4.3.1",
-				"mpath": "0.8.4",
-				"mquery": "4.0.2",
-				"ms": "2.1.2",
-				"sift": "13.5.2"
+				"bson": "^4.7.0",
+				"kareem": "2.5.1",
+				"mongodb": "4.14.0",
+				"mpath": "0.9.0",
+				"mquery": "4.0.3",
+				"ms": "2.1.3",
+				"sift": "16.0.1"
 			},
 			"engines": {
 				"node": ">=12.0.0"
@@ -18439,25 +19529,26 @@
 			}
 		},
 		"node_modules/mongoose/node_modules/mongodb": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.3.1.tgz",
-			"integrity": "sha512-sNa8APSIk+r4x31ZwctKjuPSaeKuvUeNb/fu/3B6dRM02HpEgig7hTHM8A/PJQTlxuC/KFWlDlQjhsk/S43tBg==",
+			"version": "4.14.0",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.14.0.tgz",
+			"integrity": "sha512-coGKkWXIBczZPr284tYKFLg+KbGPPLlSbdgfKAb6QqCFt5bo5VFZ50O3FFzsw4rnkqjwT6D8Qcoo9nshYKM7Mg==",
 			"dependencies": {
-				"bson": "^4.6.1",
-				"denque": "^2.0.1",
-				"mongodb-connection-string-url": "^2.4.1",
-				"socks": "^2.6.1"
+				"bson": "^4.7.0",
+				"mongodb-connection-string-url": "^2.5.4",
+				"socks": "^2.7.1"
 			},
 			"engines": {
 				"node": ">=12.9.0"
 			},
 			"optionalDependencies": {
+				"@aws-sdk/credential-providers": "^3.186.0",
 				"saslprep": "^1.0.3"
 			}
 		},
 		"node_modules/mongoose/node_modules/ms": {
-			"version": "2.1.2",
-			"license": "MIT"
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
 		},
 		"node_modules/moo": {
 			"version": "0.5.1",
@@ -18486,17 +19577,17 @@
 			}
 		},
 		"node_modules/mpath": {
-			"version": "0.8.4",
-			"resolved": "https://registry.npmjs.org/mpath/-/mpath-0.8.4.tgz",
-			"integrity": "sha512-DTxNZomBcTWlrMW76jy1wvV37X/cNNxPW1y2Jzd4DZkAaC5ZGsm8bfGfNOthcDuRJujXLqiuS6o3Tpy0JEoh7g==",
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+			"integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
 			"engines": {
 				"node": ">=4.0.0"
 			}
 		},
 		"node_modules/mquery": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/mquery/-/mquery-4.0.2.tgz",
-			"integrity": "sha512-oAVF0Nil1mT3rxty6Zln4YiD6x6QsUWYz927jZzjMxOK2aqmhEz5JQ7xmrKK7xRFA2dwV+YaOpKU/S+vfNqKxA==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/mquery/-/mquery-4.0.3.tgz",
+			"integrity": "sha512-J5heI+P08I6VJ2Ky3+33IpCdAvlYGTSUjwTPxkAr8i8EoduPMBX2OY/wa3IKZIQl7MU4SbFk8ndgSKyB/cl1zA==",
 			"dependencies": {
 				"debug": "4.x"
 			},
@@ -18505,9 +19596,9 @@
 			}
 		},
 		"node_modules/mquery/node_modules/debug": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -20104,9 +21195,9 @@
 			}
 		},
 		"node_modules/passport-local-mongoose": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/passport-local-mongoose/-/passport-local-mongoose-6.1.0.tgz",
-			"integrity": "sha512-kxRDejpBXoPmWau1RCrmEeNYEXGG9ec4aDYjd0pFAHIEAzZ0RXKn581ISfjpHZ1zZLoCCM2pWUo4SfGHNJNwnw==",
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/passport-local-mongoose/-/passport-local-mongoose-7.1.2.tgz",
+			"integrity": "sha512-hNLIKi/6IhElr/PhOze8wLDh7T4+ZYhc8GFWYApLgG7FrjI55tuGZELPtsUBqODz77OwlUUf+ngPgHN09zxGLg==",
 			"dependencies": {
 				"generaterr": "^1.5.0",
 				"passport-local": "^1.0.0",
@@ -26367,9 +27458,9 @@
 			}
 		},
 		"node_modules/sift": {
-			"version": "13.5.2",
-			"resolved": "https://registry.npmjs.org/sift/-/sift-13.5.2.tgz",
-			"integrity": "sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA=="
+			"version": "16.0.1",
+			"resolved": "https://registry.npmjs.org/sift/-/sift-16.0.1.tgz",
+			"integrity": "sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ=="
 		},
 		"node_modules/signal-exit": {
 			"version": "3.0.4",
@@ -26750,17 +27841,22 @@
 			}
 		},
 		"node_modules/socks": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
-			"integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+			"integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
 			"dependencies": {
-				"ip": "^1.1.5",
+				"ip": "^2.0.0",
 				"smart-buffer": "^4.2.0"
 			},
 			"engines": {
 				"node": ">= 10.13.0",
 				"npm": ">= 3.0.0"
 			}
+		},
+		"node_modules/socks/node_modules/ip": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+			"integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
 		},
 		"node_modules/sorted-array-functions": {
 			"version": "1.3.0",
@@ -27365,6 +28461,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/strnum": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+			"integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+			"optional": true
 		},
 		"node_modules/style-loader": {
 			"version": "3.3.1",
@@ -28482,7 +29584,7 @@
 		},
 		"node_modules/tslib": {
 			"version": "2.3.1",
-			"dev": true,
+			"devOptional": true,
 			"license": "0BSD"
 		},
 		"node_modules/tsscmp": {
@@ -30354,7 +31456,7 @@
 				"dayjs": "^1.11.3",
 				"dayjs-plugin-utc": "^0.1.2",
 				"express": "^4.17.1",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"node-fetch": "^2.6.6",
 				"node-schedule": "^2.1.0",
 				"qs": "^6.10.3",
@@ -31057,7 +32159,7 @@
 				"cors": "^2.8.5",
 				"dotenv": "6.2.0",
 				"express": "4.17.1",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"morgan": "^1.9.1",
 				"request": "2.88.0",
 				"request-promise": "4.2.4",
@@ -31898,7 +33000,7 @@
 				"dotenv": "^8.2.0",
 				"express": "^4.16.3",
 				"jsonwebtoken": "^8.3.0",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"request": "^2.87.0",
 				"request-promise": "^4.2.2",
 				"swagger-ui-express": "^4.1.4",
@@ -32341,7 +33443,7 @@
 				"JSONStream": "1.3.5",
 				"lodash": "4.17.21",
 				"lru-cache": "6.0.0",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"node-fetch": "2.6.1",
 				"rabbitmq-stats": "1.2.3",
 				"request": "2.88.2",
@@ -32916,7 +34018,7 @@
 			}
 		},
 		"services/component-repository": {
-			"version": "1.6.2",
+			"version": "1.7.1",
 			"dependencies": {
 				"@openintegrationhub/component-repository": "*",
 				"@openintegrationhub/event-bus": "*",
@@ -33174,7 +34276,7 @@
 				"koa-router": "10.0.0",
 				"koa2-swagger-ui": "5.1.0",
 				"lodash": "4.17.21",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"notation": "2.0.0"
 			},
 			"devDependencies": {
@@ -33612,7 +34714,7 @@
 				"dotenv": "^6.2.0",
 				"express": "^4.16.3",
 				"lodash": "4.17.21",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"request": "2.88.2",
 				"request-promise": "4.2.6",
 				"swagger-ui-express": "^3.0.8"
@@ -34731,7 +35833,7 @@
 				"cors": "^2.8.5",
 				"cronstrue": "^1.94.0",
 				"express": "^4.17.1",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"request": "^2.87.0",
 				"request-promise": "^4.2.5",
 				"swagger-ui-express": "^4.1.4"
@@ -35175,7 +36277,7 @@
 				"cronstrue": "^1.94.0",
 				"dot-prop": "^6.0.1",
 				"express": "^4.17.1",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"node-fetch": "^2.6.6",
 				"request": "^2.87.0",
 				"request-promise": "^4.2.5",
@@ -35479,13 +36581,13 @@
 				"lodash": "4.17.21",
 				"moment": "2.28.0",
 				"mongodb": "3.6.2",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"ms": "2.1.2",
 				"node-jose": "2.0.0",
 				"oidc-provider": "5.5.3",
 				"passport": "0.4.1",
 				"passport-jwt": "4.0.0",
-				"passport-local-mongoose": "6.1.0",
+				"passport-local-mongoose": "7.1.2",
 				"pug": "3.0.2",
 				"request": "2.88.2",
 				"request-promise": "4.2.6",
@@ -36014,7 +37116,7 @@
 				"dotenv": "^8.2.0",
 				"express": "^4.16.3",
 				"generate-schema": "^2.6.0",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"request": "2.88.2",
 				"request-promise": "4.2.6",
 				"swagger-ui-express": "^4.1.4"
@@ -36869,7 +37971,7 @@
 				"jszip": "3.2.2",
 				"mkdirp": "1.0.4",
 				"moment": "2.24.0",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"morgan": "1.9.1",
 				"multer": "1.4.2",
 				"qs": "6.10.1",
@@ -37675,7 +38777,7 @@
 				"cors": "2.8.5",
 				"express": "4.17.1",
 				"isomorphic-fetch": "3.0.0",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"swagger-ui-express": "4.1.5",
 				"uuid": "8.3.1"
 			},
@@ -37946,7 +39048,7 @@
 				"dotenv": "8.2.0",
 				"express": "4.17.1",
 				"influx": "5.6.3",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"request": "2.88.2"
 			},
 			"devDependencies": {
@@ -38339,7 +39441,7 @@
 				"backend-commons-lib": "*",
 				"cron-parser": "2.7.3",
 				"express": "4.16.3",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"nconf": "0.10.0",
 				"uuid": "3.3.2"
 			},
@@ -38631,7 +39733,7 @@
 				"jsonwebtoken": "8.5.1",
 				"lru-cache": "6.0.0",
 				"moment": "2.29.1",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"morgan": "1.10.0",
 				"node-fetch": "2.6.1",
 				"oauth": "0.9.15",
@@ -38645,7 +39747,6 @@
 				"eslint-plugin-import": "2.22.1",
 				"eslint-plugin-jest": "24.1.3",
 				"jest": "26.6.0",
-				"jest-environment-node": "^26.6.2",
 				"mongodb": "3.6.3",
 				"mongodb-memory-server": "7.4.0",
 				"nock": "13.0.5",
@@ -38747,23 +39848,6 @@
 			"version": "1.0.0",
 			"dev": true,
 			"license": "MIT"
-		},
-		"services/secret-service/node_modules/jest-environment-node": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.6.2.tgz",
-			"integrity": "sha512-zhtMio3Exty18dy8ee8eJ9kjnRyZC1N4C1Nt/VShN1apyXc8rWGtJ9lI7vqiWcyyXS4BVSEn9lxAM2D+07/Tag==",
-			"dev": true,
-			"dependencies": {
-				"@jest/environment": "^26.6.2",
-				"@jest/fake-timers": "^26.6.2",
-				"@jest/types": "^26.6.2",
-				"@types/node": "*",
-				"jest-mock": "^26.6.2",
-				"jest-util": "^26.6.2"
-			},
-			"engines": {
-				"node": ">= 10.14.2"
-			}
 		},
 		"services/secret-service/node_modules/mongodb": {
 			"version": "3.6.3",
@@ -38954,7 +40038,7 @@
 				"koa-router": "7.4.0",
 				"koa2-swagger-ui": "5.1.0",
 				"lodash": "4.17.21",
-				"mongoose": "6.2.1"
+				"mongoose": "6.10.3"
 			},
 			"devDependencies": {
 				"@tsconfig/node14": "1.0.1",
@@ -39210,7 +40294,7 @@
 				"cronstrue": "^1.94.0",
 				"express": "^4.17.1",
 				"lodash": "4.17.21",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"request": "^2.87.0",
 				"request-promise": "^4.2.5",
 				"swagger-ui-express": "^4.1.4"
@@ -39795,7 +40879,7 @@
 				"bunyan": "^1.8.14",
 				"bunyan-format": "^0.2.1",
 				"express": "4.17.1",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"node-fetch": "2.6.5"
 			},
 			"devDependencies": {
@@ -39995,6 +41079,910 @@
 		}
 	},
 	"dependencies": {
+		"@aws-crypto/ie11-detection": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+			"integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+			"optional": true,
+			"requires": {
+				"tslib": "^1.11.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+					"optional": true
+				}
+			}
+		},
+		"@aws-crypto/sha256-browser": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+			"integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+			"optional": true,
+			"requires": {
+				"@aws-crypto/ie11-detection": "^3.0.0",
+				"@aws-crypto/sha256-js": "^3.0.0",
+				"@aws-crypto/supports-web-crypto": "^3.0.0",
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@aws-sdk/util-utf8-browser": "^3.0.0",
+				"tslib": "^1.11.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+					"optional": true
+				}
+			}
+		},
+		"@aws-crypto/sha256-js": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+			"integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+			"optional": true,
+			"requires": {
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^1.11.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+					"optional": true
+				}
+			}
+		},
+		"@aws-crypto/supports-web-crypto": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+			"integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+			"optional": true,
+			"requires": {
+				"tslib": "^1.11.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+					"optional": true
+				}
+			}
+		},
+		"@aws-crypto/util": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+			"integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-utf8-browser": "^3.0.0",
+				"tslib": "^1.11.1"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+					"optional": true
+				}
+			}
+		},
+		"@aws-sdk/abort-controller": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.292.0.tgz",
+			"integrity": "sha512-lf+OPptL01kvryIJy7+dvFux5KbJ6OTwLPPEekVKZ2AfEvwcVtOZWFUhyw3PJCBTVncjKB1Kjl3V/eTS3YuPXQ==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/client-cognito-identity": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.292.0.tgz",
+			"integrity": "sha512-xDdpB5xhfN31rXgjC84WoneMX7wObMJkyb5Vat838XMKWKAZLNZmt/3p6OcAmkCwupL8LqS2oSG0Bp+uJOjyGg==",
+			"optional": true,
+			"requires": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/client-sts": "3.292.0",
+				"@aws-sdk/config-resolver": "3.292.0",
+				"@aws-sdk/credential-provider-node": "3.292.0",
+				"@aws-sdk/fetch-http-handler": "3.292.0",
+				"@aws-sdk/hash-node": "3.292.0",
+				"@aws-sdk/invalid-dependency": "3.292.0",
+				"@aws-sdk/middleware-content-length": "3.292.0",
+				"@aws-sdk/middleware-endpoint": "3.292.0",
+				"@aws-sdk/middleware-host-header": "3.292.0",
+				"@aws-sdk/middleware-logger": "3.292.0",
+				"@aws-sdk/middleware-recursion-detection": "3.292.0",
+				"@aws-sdk/middleware-retry": "3.292.0",
+				"@aws-sdk/middleware-serde": "3.292.0",
+				"@aws-sdk/middleware-signing": "3.292.0",
+				"@aws-sdk/middleware-stack": "3.292.0",
+				"@aws-sdk/middleware-user-agent": "3.292.0",
+				"@aws-sdk/node-config-provider": "3.292.0",
+				"@aws-sdk/node-http-handler": "3.292.0",
+				"@aws-sdk/protocol-http": "3.292.0",
+				"@aws-sdk/smithy-client": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"@aws-sdk/url-parser": "3.292.0",
+				"@aws-sdk/util-base64": "3.292.0",
+				"@aws-sdk/util-body-length-browser": "3.292.0",
+				"@aws-sdk/util-body-length-node": "3.292.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.292.0",
+				"@aws-sdk/util-defaults-mode-node": "3.292.0",
+				"@aws-sdk/util-endpoints": "3.292.0",
+				"@aws-sdk/util-retry": "3.292.0",
+				"@aws-sdk/util-user-agent-browser": "3.292.0",
+				"@aws-sdk/util-user-agent-node": "3.292.0",
+				"@aws-sdk/util-utf8": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/client-sso": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.292.0.tgz",
+			"integrity": "sha512-DzBBa72TTgfTllvTbD/7KcRY8bo5ExUv8gHJaedrE7mlZUn/2msk9S41rf+Rcwb0bf7k14Y36aRVwoXwQCKPLg==",
+			"optional": true,
+			"requires": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/config-resolver": "3.292.0",
+				"@aws-sdk/fetch-http-handler": "3.292.0",
+				"@aws-sdk/hash-node": "3.292.0",
+				"@aws-sdk/invalid-dependency": "3.292.0",
+				"@aws-sdk/middleware-content-length": "3.292.0",
+				"@aws-sdk/middleware-endpoint": "3.292.0",
+				"@aws-sdk/middleware-host-header": "3.292.0",
+				"@aws-sdk/middleware-logger": "3.292.0",
+				"@aws-sdk/middleware-recursion-detection": "3.292.0",
+				"@aws-sdk/middleware-retry": "3.292.0",
+				"@aws-sdk/middleware-serde": "3.292.0",
+				"@aws-sdk/middleware-stack": "3.292.0",
+				"@aws-sdk/middleware-user-agent": "3.292.0",
+				"@aws-sdk/node-config-provider": "3.292.0",
+				"@aws-sdk/node-http-handler": "3.292.0",
+				"@aws-sdk/protocol-http": "3.292.0",
+				"@aws-sdk/smithy-client": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"@aws-sdk/url-parser": "3.292.0",
+				"@aws-sdk/util-base64": "3.292.0",
+				"@aws-sdk/util-body-length-browser": "3.292.0",
+				"@aws-sdk/util-body-length-node": "3.292.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.292.0",
+				"@aws-sdk/util-defaults-mode-node": "3.292.0",
+				"@aws-sdk/util-endpoints": "3.292.0",
+				"@aws-sdk/util-retry": "3.292.0",
+				"@aws-sdk/util-user-agent-browser": "3.292.0",
+				"@aws-sdk/util-user-agent-node": "3.292.0",
+				"@aws-sdk/util-utf8": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/client-sso-oidc": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.292.0.tgz",
+			"integrity": "sha512-KANoinZDvWwCXKrx92V0i8ItovKwW94Ep4vLY+D7ZmuV8IACK0XcIR9HF8eMR4Zqy7DSBAGdvvd318Qy2v1f2Q==",
+			"optional": true,
+			"requires": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/config-resolver": "3.292.0",
+				"@aws-sdk/fetch-http-handler": "3.292.0",
+				"@aws-sdk/hash-node": "3.292.0",
+				"@aws-sdk/invalid-dependency": "3.292.0",
+				"@aws-sdk/middleware-content-length": "3.292.0",
+				"@aws-sdk/middleware-endpoint": "3.292.0",
+				"@aws-sdk/middleware-host-header": "3.292.0",
+				"@aws-sdk/middleware-logger": "3.292.0",
+				"@aws-sdk/middleware-recursion-detection": "3.292.0",
+				"@aws-sdk/middleware-retry": "3.292.0",
+				"@aws-sdk/middleware-serde": "3.292.0",
+				"@aws-sdk/middleware-stack": "3.292.0",
+				"@aws-sdk/middleware-user-agent": "3.292.0",
+				"@aws-sdk/node-config-provider": "3.292.0",
+				"@aws-sdk/node-http-handler": "3.292.0",
+				"@aws-sdk/protocol-http": "3.292.0",
+				"@aws-sdk/smithy-client": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"@aws-sdk/url-parser": "3.292.0",
+				"@aws-sdk/util-base64": "3.292.0",
+				"@aws-sdk/util-body-length-browser": "3.292.0",
+				"@aws-sdk/util-body-length-node": "3.292.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.292.0",
+				"@aws-sdk/util-defaults-mode-node": "3.292.0",
+				"@aws-sdk/util-endpoints": "3.292.0",
+				"@aws-sdk/util-retry": "3.292.0",
+				"@aws-sdk/util-user-agent-browser": "3.292.0",
+				"@aws-sdk/util-user-agent-node": "3.292.0",
+				"@aws-sdk/util-utf8": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/client-sts": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.292.0.tgz",
+			"integrity": "sha512-t9Q0+iT8E1QAARq7aUHdF5KwgXrdW1yl4lsnkmVcLJKypyhnXTVJ68qldV6rBDSFswGqT0SBQBzcAj6vPNlOFQ==",
+			"optional": true,
+			"requires": {
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/config-resolver": "3.292.0",
+				"@aws-sdk/credential-provider-node": "3.292.0",
+				"@aws-sdk/fetch-http-handler": "3.292.0",
+				"@aws-sdk/hash-node": "3.292.0",
+				"@aws-sdk/invalid-dependency": "3.292.0",
+				"@aws-sdk/middleware-content-length": "3.292.0",
+				"@aws-sdk/middleware-endpoint": "3.292.0",
+				"@aws-sdk/middleware-host-header": "3.292.0",
+				"@aws-sdk/middleware-logger": "3.292.0",
+				"@aws-sdk/middleware-recursion-detection": "3.292.0",
+				"@aws-sdk/middleware-retry": "3.292.0",
+				"@aws-sdk/middleware-sdk-sts": "3.292.0",
+				"@aws-sdk/middleware-serde": "3.292.0",
+				"@aws-sdk/middleware-signing": "3.292.0",
+				"@aws-sdk/middleware-stack": "3.292.0",
+				"@aws-sdk/middleware-user-agent": "3.292.0",
+				"@aws-sdk/node-config-provider": "3.292.0",
+				"@aws-sdk/node-http-handler": "3.292.0",
+				"@aws-sdk/protocol-http": "3.292.0",
+				"@aws-sdk/smithy-client": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"@aws-sdk/url-parser": "3.292.0",
+				"@aws-sdk/util-base64": "3.292.0",
+				"@aws-sdk/util-body-length-browser": "3.292.0",
+				"@aws-sdk/util-body-length-node": "3.292.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.292.0",
+				"@aws-sdk/util-defaults-mode-node": "3.292.0",
+				"@aws-sdk/util-endpoints": "3.292.0",
+				"@aws-sdk/util-retry": "3.292.0",
+				"@aws-sdk/util-user-agent-browser": "3.292.0",
+				"@aws-sdk/util-user-agent-node": "3.292.0",
+				"@aws-sdk/util-utf8": "3.292.0",
+				"fast-xml-parser": "4.1.2",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/config-resolver": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.292.0.tgz",
+			"integrity": "sha512-cB3twnNR7vYvlt2jvw8VlA1+iv/tVzl+/S39MKqw2tepU+AbJAM0EHwb/dkf1OKSmlrnANXhshx80MHF9zL4mA==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/signature-v4": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"@aws-sdk/util-config-provider": "3.292.0",
+				"@aws-sdk/util-middleware": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/credential-provider-cognito-identity": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.292.0.tgz",
+			"integrity": "sha512-UoAyoS1Dx2yVT/LJUnH2LBojyb0go9xJWnO6hhQFeU8iFCvM/GbNA/v1daf6V7FBbujfYcK3pVP66BlYXX6I5w==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/client-cognito-identity": "3.292.0",
+				"@aws-sdk/property-provider": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/credential-provider-env": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.292.0.tgz",
+			"integrity": "sha512-YbafSG0ZEKE2969CJWVtUhh3hfOeLPecFVoXOtegCyAJgY5Ghtu4TsVhL4DgiGAgOC30ojAmUVQEXzd7xJF5xA==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/property-provider": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/credential-provider-imds": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.292.0.tgz",
+			"integrity": "sha512-W/peOgDSRYulgzFpUhvgi1pCm6piBz6xrVN17N4QOy+3NHBXRVMVzYk6ct2qpLPgJUSEZkcpP+Gds+bBm8ed1A==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/node-config-provider": "3.292.0",
+				"@aws-sdk/property-provider": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"@aws-sdk/url-parser": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/credential-provider-ini": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.292.0.tgz",
+			"integrity": "sha512-gTXSGjx3Q+KY8Zz/XHTDWOBx9UWtL3s8tTdpQOdaMqqm0xIK5X4KDud3L/huPpZYm0a7rNAML8l1mU56FFnBVw==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/credential-provider-env": "3.292.0",
+				"@aws-sdk/credential-provider-imds": "3.292.0",
+				"@aws-sdk/credential-provider-process": "3.292.0",
+				"@aws-sdk/credential-provider-sso": "3.292.0",
+				"@aws-sdk/credential-provider-web-identity": "3.292.0",
+				"@aws-sdk/property-provider": "3.292.0",
+				"@aws-sdk/shared-ini-file-loader": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/credential-provider-node": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.292.0.tgz",
+			"integrity": "sha512-85LQIeSGSQtbrgqEYmCcUnehBmTKt8bbn7mN9RxbtCDnZVgEagJCid7o9+fYQXZ5IjXaHLUApoLsv6ytEj4ITA==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/credential-provider-env": "3.292.0",
+				"@aws-sdk/credential-provider-imds": "3.292.0",
+				"@aws-sdk/credential-provider-ini": "3.292.0",
+				"@aws-sdk/credential-provider-process": "3.292.0",
+				"@aws-sdk/credential-provider-sso": "3.292.0",
+				"@aws-sdk/credential-provider-web-identity": "3.292.0",
+				"@aws-sdk/property-provider": "3.292.0",
+				"@aws-sdk/shared-ini-file-loader": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/credential-provider-process": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.292.0.tgz",
+			"integrity": "sha512-CFVXuMuUvg/a4tknzRikEDwZBnKlHs1LZCpTXIGjBdUTdosoi4WNzDLzGp93ZRTtcgFz+4wirz2f7P3lC0NrQw==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/property-provider": "3.292.0",
+				"@aws-sdk/shared-ini-file-loader": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/credential-provider-sso": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.292.0.tgz",
+			"integrity": "sha512-+jrhi0oZc9dMtbRsqi+lkqIheCb8QlsRJSEKDa3nUlyxaOkzRKR9Yf5Jtpqooa0ichFhMVZTD9oXPFrlGROIEQ==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/client-sso": "3.292.0",
+				"@aws-sdk/property-provider": "3.292.0",
+				"@aws-sdk/shared-ini-file-loader": "3.292.0",
+				"@aws-sdk/token-providers": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/credential-provider-web-identity": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.292.0.tgz",
+			"integrity": "sha512-4DbtIEM9gGVfqYlMdYXg3XY+vBhemjB1zXIequottW8loLYM8Vuz4/uGxxKNze6evVVzowsA0wKrYclE1aj/Rg==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/property-provider": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/credential-providers": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.292.0.tgz",
+			"integrity": "sha512-0PjOmi1JzbfaW+4fKxIzxviiZ4FZiW/0MT6ba0hMVldoXQYpLkmTJx1Hfsvw5o2eqCVJ5kLYEIjLnmrKKR3WUQ==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/client-cognito-identity": "3.292.0",
+				"@aws-sdk/client-sso": "3.292.0",
+				"@aws-sdk/client-sts": "3.292.0",
+				"@aws-sdk/credential-provider-cognito-identity": "3.292.0",
+				"@aws-sdk/credential-provider-env": "3.292.0",
+				"@aws-sdk/credential-provider-imds": "3.292.0",
+				"@aws-sdk/credential-provider-ini": "3.292.0",
+				"@aws-sdk/credential-provider-node": "3.292.0",
+				"@aws-sdk/credential-provider-process": "3.292.0",
+				"@aws-sdk/credential-provider-sso": "3.292.0",
+				"@aws-sdk/credential-provider-web-identity": "3.292.0",
+				"@aws-sdk/property-provider": "3.292.0",
+				"@aws-sdk/shared-ini-file-loader": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/fetch-http-handler": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.292.0.tgz",
+			"integrity": "sha512-zh3bhUJbL8RSa39ZKDcy+AghtUkIP8LwcNlwRIoxMQh3Row4D1s4fCq0KZCx98NJBEXoiTLyTQlZxxI//BOb1Q==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/protocol-http": "3.292.0",
+				"@aws-sdk/querystring-builder": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"@aws-sdk/util-base64": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/hash-node": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.292.0.tgz",
+			"integrity": "sha512-1yLxmIsvE+eK36JXEgEIouTITdykQLVhsA5Oai//Lar6Ddgu1sFpLDbdkMtKbrh4I0jLN9RacNCkeVQjZPTCCQ==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/types": "3.292.0",
+				"@aws-sdk/util-buffer-from": "3.292.0",
+				"@aws-sdk/util-utf8": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/invalid-dependency": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.292.0.tgz",
+			"integrity": "sha512-39OUV78CD3TmEbjhpt+V+Fk4wAGWhixqHxDSN8+4WL0uB4Fl7k5m3Z9hNY78AttHQSl2twR7WtLztnXPAFsriw==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/is-array-buffer": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.292.0.tgz",
+			"integrity": "sha512-kW/G5T/fzI0sJH5foZG6XJiNCevXqKLxV50qIT4B1pMuw7regd4ALIy0HwSqj1nnn9mSbRWBfmby0jWCJsMcwg==",
+			"optional": true,
+			"requires": {
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/middleware-content-length": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.292.0.tgz",
+			"integrity": "sha512-2gMWzQus5mj14menolpPDbYBeaOYcj7KNFZOjTjjI3iQ0KqyetG6XasirNrcJ/8QX1BRmpTol8Xjp2Ue3Gbzwg==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/protocol-http": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/middleware-endpoint": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.292.0.tgz",
+			"integrity": "sha512-cPMkiSxpZGG6tYlW4OS+ucS6r43f9ddX9kcUoemJCY10MOuogdPjulCAjE0HTs2PLKSOrrG4CTP4Q4wWDrH4Bw==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/middleware-serde": "3.292.0",
+				"@aws-sdk/protocol-http": "3.292.0",
+				"@aws-sdk/signature-v4": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"@aws-sdk/url-parser": "3.292.0",
+				"@aws-sdk/util-config-provider": "3.292.0",
+				"@aws-sdk/util-middleware": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/middleware-host-header": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.292.0.tgz",
+			"integrity": "sha512-mHuCWe3Yg2S5YZ7mB7sKU6C97XspfqrimWjMW9pfV2usAvLA3R0HrB03jpR5vpZ3P4q7HB6wK3S6CjYMGGRNag==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/protocol-http": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/middleware-logger": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.292.0.tgz",
+			"integrity": "sha512-yZNY1XYmG3NG+uonET7jzKXNiwu61xm/ZZ6i/l51SusuaYN+qQtTAhOFsieQqTehF9kP4FzbsWgPDwD8ZZX9lw==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/middleware-recursion-detection": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.292.0.tgz",
+			"integrity": "sha512-kA3VZpPko0Zqd7CYPTKAxhjEv0HJqFu2054L04dde1JLr43ro+2MTdX7vsHzeAFUVRphqatFFofCumvXmU6Mig==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/protocol-http": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/middleware-retry": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.292.0.tgz",
+			"integrity": "sha512-wUuXwiwMwFNMTgc9oFeUHkgpF56EfLJl/EtRn2376k9sFd7JoFu3zTo3VTGROLH/88r20A01TOr9g/cFjXgCJQ==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/protocol-http": "3.292.0",
+				"@aws-sdk/service-error-classification": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"@aws-sdk/util-middleware": "3.292.0",
+				"@aws-sdk/util-retry": "3.292.0",
+				"tslib": "^2.3.1",
+				"uuid": "^8.3.2"
+			}
+		},
+		"@aws-sdk/middleware-sdk-sts": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.292.0.tgz",
+			"integrity": "sha512-GN5ZHEqXZqDi+HkVbaXRX9HaW/vA5rikYpWKYsmxTUZ7fB7ijvEO3co3lleJv2C+iGYRtUIHC4wYNB5xgoTCxg==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/middleware-signing": "3.292.0",
+				"@aws-sdk/property-provider": "3.292.0",
+				"@aws-sdk/protocol-http": "3.292.0",
+				"@aws-sdk/signature-v4": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/middleware-serde": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.292.0.tgz",
+			"integrity": "sha512-6hN9mTQwSvV8EcGvtXbS/MpK7WMCokUku5Wu7X24UwCNMVkoRHLIkYcxHcvBTwttuOU0d8hph1/lIX4dkLwkQw==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/middleware-signing": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.292.0.tgz",
+			"integrity": "sha512-GVfoSjDjEQ4TaO6x9MffyP3uRV+2KcS5FtexLCYOM9pJcnE9tqq9FJOrZ1xl1g+YjUVKxo4x8lu3tpEtIb17qg==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/property-provider": "3.292.0",
+				"@aws-sdk/protocol-http": "3.292.0",
+				"@aws-sdk/signature-v4": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"@aws-sdk/util-middleware": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/middleware-stack": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.292.0.tgz",
+			"integrity": "sha512-WdQpRkuMysrEwrkByCM1qCn2PPpFGGQ2iXqaFha5RzCdZDlxJni9cVNb6HzWUcgjLEYVTXCmOR9Wxm3CNW44Qg==",
+			"optional": true,
+			"requires": {
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/middleware-user-agent": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.292.0.tgz",
+			"integrity": "sha512-PvGMfPwfW1nq9fzWKIIS6USjY70FfdmiZhFL/TyoaTp8gV/Y1+Le8i6E1LegDbnbE/LS5IBuNgUzdserYcfbOQ==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/protocol-http": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/node-config-provider": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.292.0.tgz",
+			"integrity": "sha512-S3NnC9dQ5GIbJYSDIldZb4zdpCOEua1tM7bjYL3VS5uqCEM93kIi/o/UkIUveMp/eqTS2LJa5HjNIz5Te6je0A==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/property-provider": "3.292.0",
+				"@aws-sdk/shared-ini-file-loader": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/node-http-handler": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.292.0.tgz",
+			"integrity": "sha512-L/E3UDSwXLXjt1XWWh0RBD55F+aZI1AEdPwdES9i1PjnZLyuxuDhEDptVibNN56+I9/4Q3SbmuVRVlOD0uzBag==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/abort-controller": "3.292.0",
+				"@aws-sdk/protocol-http": "3.292.0",
+				"@aws-sdk/querystring-builder": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/property-provider": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.292.0.tgz",
+			"integrity": "sha512-dHArSvsiqhno/g55N815gXmAMrmN8DP7OeFNqJ4wJG42xsF2PFN3DAsjIuHuXMwu+7A3R1LHqIpvv0hA9KeoJQ==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/protocol-http": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.292.0.tgz",
+			"integrity": "sha512-NLi4fq3k41aXIh1I97yX0JTy+3p6aW1NdwFwdMa674z86QNfb4SfRQRZBQe9wEnAZ/eWHVnlKIuII+U1URk/Kg==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/querystring-builder": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.292.0.tgz",
+			"integrity": "sha512-XElIFJaReIm24eEvBtV2dOtZvcm3gXsGu/ftG8MLJKbKXFKpAP1q+K6En0Bs7/T88voKghKdKpKT+eZUWgTqlg==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/types": "3.292.0",
+				"@aws-sdk/util-uri-escape": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/querystring-parser": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.292.0.tgz",
+			"integrity": "sha512-iTYpYo7a8X9RxiPbjjewIpm6XQPx2EOcF1dWCPRII9EFlmZ4bwnX+PDI36fIo9oVs8TIKXmwNGODU9nsg7CSAw==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/service-error-classification": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.292.0.tgz",
+			"integrity": "sha512-X1k3sixCeC45XSNHBe+kRBQBwPDyTFtFITb8O5Qw4dS9XWGhrUJT4CX0qE5aj8qP3F9U5nRizs9c2mBVVP0Caw==",
+			"optional": true
+		},
+		"@aws-sdk/shared-ini-file-loader": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.292.0.tgz",
+			"integrity": "sha512-Av2TTYg1Jig2kbkD56ybiqZJB6vVrYjv1W5UQwY/q3nA/T2mcrgQ20ByCOt5Bv9VvY7FSgC+znj+L4a7RLGmBg==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/signature-v4": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.292.0.tgz",
+			"integrity": "sha512-+rw47VY5mvBecn13tDQTl1ipGWg5tE63faWgmZe68HoBL87ZiDzsd7bUKOvjfW21iMgWlwAppkaNNQayYRb2zg==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/is-array-buffer": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"@aws-sdk/util-hex-encoding": "3.292.0",
+				"@aws-sdk/util-middleware": "3.292.0",
+				"@aws-sdk/util-uri-escape": "3.292.0",
+				"@aws-sdk/util-utf8": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/smithy-client": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.292.0.tgz",
+			"integrity": "sha512-S8PKzjPkZ6SXYZuZiU787dMsvQ0d/LFEhw2OI4Oe2An9Fc2IwJ2FYukyHoQJOV2tV0DiuMebPo7eMyQyjKElvA==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/middleware-stack": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/token-providers": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.292.0.tgz",
+			"integrity": "sha512-RJ+fQp/SsMnuH+WrTWaLR2Kq1b/fQdSq4zDwtauultSEBQknd7RAgjQ4JBVaIwR66vJjQPa3MXYfgja/oONT+w==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/client-sso-oidc": "3.292.0",
+				"@aws-sdk/property-provider": "3.292.0",
+				"@aws-sdk/shared-ini-file-loader": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/types": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.292.0.tgz",
+			"integrity": "sha512-1teYAY2M73UXZxMAxqZxVS2qwXjQh0OWtt7qyLfha0TtIk/fZ1hRwFgxbDCHUFcdNBSOSbKH/ESor90KROXLCQ==",
+			"optional": true,
+			"requires": {
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/url-parser": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.292.0.tgz",
+			"integrity": "sha512-NZeAuZCk1x6TIiWuRfbOU6wHPBhf0ly2qOHzWut4BCH+b4RrDmFF8EmXcH1auEfGhE7yRyR6XqIN0t3S+hYACA==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/querystring-parser": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/util-base64": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.292.0.tgz",
+			"integrity": "sha512-zjNCwNdy617yFvEjZorepNWXB2sQCVfsShCwFy/kIQ5iW5tT2jQKaqc0K77diU9atkooxw9p1W9m9sOgrkOFNw==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/util-buffer-from": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/util-body-length-browser": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.292.0.tgz",
+			"integrity": "sha512-Wd/BM+JsMiKvKs/bN3z6TredVEHh2pKudGfg3CSjTRpqFpOG903KDfyHBD42yg5PuCHoHoewJvTPKwgn7/vhaw==",
+			"optional": true,
+			"requires": {
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/util-body-length-node": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.292.0.tgz",
+			"integrity": "sha512-BBgipZ2P6RhogWE/qj0oqpdlyd3iSBYmb+aD/TBXwB2lA/X8A99GxweBd/kp06AmcJRoMS9WIXgbWkiiBlRlSA==",
+			"optional": true,
+			"requires": {
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/util-buffer-from": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.292.0.tgz",
+			"integrity": "sha512-RxNZjLoXNxHconH9TYsk5RaEBjSgTtozHeyIdacaHPj5vlQKi4hgL2hIfKeeNiAfQEVjaUFF29lv81xpNMzVMQ==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/is-array-buffer": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/util-config-provider": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.292.0.tgz",
+			"integrity": "sha512-t3noYll6bPRSxeeNNEkC5czVjAiTPcsq00OwfJ2xyUqmquhLEfLwoJKmrT1uP7DjIEXdUtfoIQ2jWiIVm/oO5A==",
+			"optional": true,
+			"requires": {
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/util-defaults-mode-browser": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.292.0.tgz",
+			"integrity": "sha512-7+zVUlMGfa8/KT++9humHo6IDxTnxMCmWUj5jVNlkpk6h7Ecmppf7aXotviyVIA43lhtz0p2AErs0N0ekEUK+w==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/property-provider": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/util-defaults-mode-node": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.292.0.tgz",
+			"integrity": "sha512-SSIw85eF4BVs0fOJRyshT+R3b/UmBPhiVKCUZm2rq6+lIGkDPiSwQU3d/80AhXtiL5SFT/IzAKKgQd8qMa7q3A==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/config-resolver": "3.292.0",
+				"@aws-sdk/credential-provider-imds": "3.292.0",
+				"@aws-sdk/node-config-provider": "3.292.0",
+				"@aws-sdk/property-provider": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/util-endpoints": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.292.0.tgz",
+			"integrity": "sha512-CvNES1YaickVE8Iu2EP4ywdiCNy8thRnyXdx7v1d39NLeTQuMWJyM/cazWQIBv0WPYOrAnjsWb5Nw05GwpwSdA==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/util-hex-encoding": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.292.0.tgz",
+			"integrity": "sha512-qBd5KFIUywQ3qSSbj814S2srk0vfv8A6QMI+Obs1y2LHZFdQN5zViptI4UhXhKOHe+NnrHWxSuLC/LMH6q3SmA==",
+			"optional": true,
+			"requires": {
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/util-locate-window": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.292.0.tgz",
+			"integrity": "sha512-6xnFJXZI9pKw5lQCDvuWA5PnOaUtNRKWwdxvGkkLx5orboFaoVMS6zowjSQxwVNRjW82u6dYNkhmj9mZ8VSjWg==",
+			"optional": true,
+			"requires": {
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/util-middleware": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.292.0.tgz",
+			"integrity": "sha512-KjhS7flfoBKDxbiBZjLjMvEizXgjfQb7GQEItgzGoI9rfGCmZtvqCcqQQoIlxb8bIzGRggAUHtBGWnlLbpb+GQ==",
+			"optional": true,
+			"requires": {
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/util-retry": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.292.0.tgz",
+			"integrity": "sha512-JEHyF7MpVeRF5uR4LDYgpOKcFpOPiAj8TqN46SVOQQcL1K+V7cSr7O7N7J6MwJaN9XOzAcBadeIupMm7/BFbgw==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/service-error-classification": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/util-uri-escape": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.292.0.tgz",
+			"integrity": "sha512-hOQtUMQ4VcQ9iwKz50AoCp1XBD5gJ9nly/gJZccAM7zSA5mOO8RRKkbdonqquVHxrO0CnYgiFeCh3V35GFecUw==",
+			"optional": true,
+			"requires": {
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/util-user-agent-browser": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.292.0.tgz",
+			"integrity": "sha512-dld+lpC3QdmTQHdBWJ0WFDkXDSrJgfz03q6mQ8+7H+BC12ZhT0I0g9iuvUjolqy7QR00OxOy47Y9FVhq8EC0Gg==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/types": "3.292.0",
+				"bowser": "^2.11.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/util-user-agent-node": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.292.0.tgz",
+			"integrity": "sha512-f+NfIMal5E61MDc5WGhUEoicr7b1eNNhA+GgVdSB/Hg5fYhEZvFK9RZizH5rrtsLjjgcr9nPYSR7/nDKCJLumw==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/node-config-provider": "3.292.0",
+				"@aws-sdk/types": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/util-utf8": {
+			"version": "3.292.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.292.0.tgz",
+			"integrity": "sha512-FPkj+Z59/DQWvoVu2wFaRncc3KVwe/pgK3MfVb0Lx+Ibey5KUx+sNpJmYcVYHUAe/Nv/JeIpOtYuC96IXOnI6w==",
+			"optional": true,
+			"requires": {
+				"@aws-sdk/util-buffer-from": "3.292.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/util-utf8-browser": {
+			"version": "3.259.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+			"integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+			"optional": true,
+			"requires": {
+				"tslib": "^2.3.1"
+			}
+		},
 		"@babel/code-frame": {
 			"version": "7.12.11",
 			"requires": {
@@ -42002,7 +43990,6 @@
 			"requires": {
 				"@faker-js/faker": "^6.0.0-alpha.6",
 				"@openintegrationhub/iam-utils": "*",
-				"body-parser": "1.19.0",
 				"bunyan": "1.8.14",
 				"chai": "4.3.4",
 				"cors": "2.8.5",
@@ -42013,7 +44000,7 @@
 				"express-async-handler": "1.1.4",
 				"lodash": "4.17.21",
 				"mocha": "9.1.1",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"nock": "13.0.2",
 				"node-fetch": "2.6.1",
 				"sinon": "9.0.2",
@@ -44605,7 +46592,7 @@
 				"mongod": "^2.0.0",
 				"mongodb": "^3.5.9",
 				"mongodb-memory-server": "7.4.0",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"nock": "^13.0.2",
 				"node-fetch": "^2.6.6",
 				"node-schedule": "^2.1.0",
@@ -45210,7 +47197,7 @@
 				"jest": "26.6.0",
 				"mongodb": "4.1.2",
 				"mongodb-memory-server": "7.4.0",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"morgan": "^1.9.1",
 				"nock": "10.0.4",
 				"nodemon": "2.0.4",
@@ -46040,7 +48027,7 @@
 				"mongod": "^2.0.0",
 				"mongodb": "^3.5.9",
 				"mongodb-memory-server": "7.4.0",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"nock": "^13.0.2",
 				"nodemon": "2.0.4",
 				"path": "^0.12.7",
@@ -46785,6 +48772,12 @@
 			"version": "1.0.0",
 			"dev": true
 		},
+		"bowser": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+			"integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+			"optional": true
+		},
 		"boxen": {
 			"version": "4.2.0",
 			"dev": true,
@@ -46862,9 +48855,9 @@
 			}
 		},
 		"bson": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/bson/-/bson-4.6.1.tgz",
-			"integrity": "sha512-I1LQ7Hz5zgwR4QquilLNZwbhPw0Apx7i7X9kGMBTsqPdml/03Q9NBtD9nt/19ahjlphktQImrnderxqpzeVDjw==",
+			"version": "4.7.2",
+			"resolved": "https://registry.npmjs.org/bson/-/bson-4.7.2.tgz",
+			"integrity": "sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==",
 			"requires": {
 				"buffer": "^5.6.0"
 			}
@@ -47408,7 +49401,7 @@
 				"lodash": "4.17.21",
 				"lru-cache": "6.0.0",
 				"mocha": "9.1.1",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"nock": "13.0.4",
 				"node-fetch": "2.6.1",
 				"nodemon": "2.0.4",
@@ -48820,7 +50813,7 @@
 				"koa2-swagger-ui": "5.1.0",
 				"lodash": "4.17.21",
 				"mocha": "9.1.1",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"nock": "10.0.6",
 				"notation": "2.0.0",
 				"supertest": "4.0.2",
@@ -49327,7 +51320,8 @@
 			"version": "1.0.0"
 		},
 		"denque": {
-			"version": "2.0.1"
+			"version": "2.0.1",
+			"dev": true
 		},
 		"depd": {
 			"version": "1.1.2"
@@ -49430,7 +51424,7 @@
 				"jest-environment-node": "^24.7.1",
 				"lodash": "4.17.21",
 				"mongodb-memory-server": "7.4.0",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"nock": "11.3.3",
 				"nodemon": "2.0.4",
 				"request": "2.88.2",
@@ -50346,7 +52340,7 @@
 				"faker": "5.5.3",
 				"form-data": "4.0.0",
 				"lodash": "4.17.21",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"node-fetch": "2.6.1",
 				"prettier": "2.2.1",
 				"uuid": "8.3.2",
@@ -51580,6 +53574,15 @@
 			"version": "2.1.1",
 			"dev": true
 		},
+		"fast-xml-parser": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+			"integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+			"optional": true,
+			"requires": {
+				"strnum": "^1.0.5"
+			}
+		},
 		"fastq": {
 			"version": "1.13.0",
 			"dev": true,
@@ -51780,7 +53783,7 @@
 				"mongod": "^2.0.0",
 				"mongodb": "4.1.2",
 				"mongodb-memory-server": "7.4.0",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"nock": "^13.0.2",
 				"nodemon": "^2.0.4",
 				"path": "^0.12.7",
@@ -52541,7 +54544,7 @@
 				"jest-environment-node": "26.6.0",
 				"mongodb": "4.1.2",
 				"mongodb-memory-server": "7.4.0",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"nock": "^13.0.2",
 				"node-fetch": "^2.6.6",
 				"nodemon": "^2.0.4",
@@ -53322,7 +55325,7 @@
 				"moment": "2.28.0",
 				"mongodb": "3.6.2",
 				"mongodb-memory-server": "7.4.0",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"ms": "2.1.2",
 				"node-forge": "0.10.0",
 				"node-jose": "2.0.0",
@@ -53330,7 +55333,7 @@
 				"oidc-provider": "5.5.3",
 				"passport": "0.4.1",
 				"passport-jwt": "4.0.0",
-				"passport-local-mongoose": "6.1.0",
+				"passport-local-mongoose": "7.1.2",
 				"pug": "3.0.2",
 				"request": "2.88.2",
 				"request-promise": "4.2.6",
@@ -53734,7 +55737,7 @@
 				"mongod": "^2.0.0",
 				"mongodb": "4.1.2",
 				"mongodb-memory-server": "7.4.0",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"nock": "^13.0.2",
 				"nyc": "^15.1.0",
 				"path": "^0.12.7",
@@ -54115,7 +56118,8 @@
 		"ip": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+			"dev": true
 		},
 		"ipaddr.js": {
 			"version": "1.9.1"
@@ -55929,9 +57933,9 @@
 			}
 		},
 		"kareem": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.3.tgz",
-			"integrity": "sha512-uESCXM2KdtOQ8LOvKyTUXEeg0MkYp4wGglTIpGcYHvjJcS5sn2Wkfrfit8m4xSbaNDAw2KdI9elgkOxZbrFYbg=="
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
+			"integrity": "sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA=="
 		},
 		"kerberos": {
 			"version": "1.1.7",
@@ -56882,7 +58886,7 @@
 				"moment": "2.24.0",
 				"mongodb": "3.6.3",
 				"mongodb-memory-server": "7.4.1",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"morgan": "1.9.1",
 				"multer": "1.4.2",
 				"nock": "11.6.0",
@@ -57694,9 +59698,9 @@
 			}
 		},
 		"mongodb-connection-string-url": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.4.2.tgz",
-			"integrity": "sha512-mZUXF6nUzRWk5J3h41MsPv13ukWlH4jOMSk6astVeoZ1EbdTJyF5I3wxKkvqBAOoVtzLgyEYUvDjrGdcPlKjAw==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+			"integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
 			"requires": {
 				"@types/whatwg-url": "^8.2.1",
 				"whatwg-url": "^11.0.0"
@@ -57875,33 +59879,35 @@
 			}
 		},
 		"mongoose": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.2.1.tgz",
-			"integrity": "sha512-VxY1wvlc4uBQKyKNVDoEkTU3/ayFOD//qVXYP+sFyvTRbAj9/M53UWTERd84pWogs2TqAC6DTvZbxCs2LoOd3Q==",
+			"version": "6.10.3",
+			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.10.3.tgz",
+			"integrity": "sha512-fZ3pIlQn7lM632r1l4qiU58lKrJ+FufKVG8TNeRXSChAeu9alCl5KoQ9bLw4jnQNYevSq9o+sqZmFDHP+EVW3g==",
 			"requires": {
-				"bson": "^4.2.2",
-				"kareem": "2.3.3",
-				"mongodb": "4.3.1",
-				"mpath": "0.8.4",
-				"mquery": "4.0.2",
-				"ms": "2.1.2",
-				"sift": "13.5.2"
+				"bson": "^4.7.0",
+				"kareem": "2.5.1",
+				"mongodb": "4.14.0",
+				"mpath": "0.9.0",
+				"mquery": "4.0.3",
+				"ms": "2.1.3",
+				"sift": "16.0.1"
 			},
 			"dependencies": {
 				"mongodb": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.3.1.tgz",
-					"integrity": "sha512-sNa8APSIk+r4x31ZwctKjuPSaeKuvUeNb/fu/3B6dRM02HpEgig7hTHM8A/PJQTlxuC/KFWlDlQjhsk/S43tBg==",
+					"version": "4.14.0",
+					"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.14.0.tgz",
+					"integrity": "sha512-coGKkWXIBczZPr284tYKFLg+KbGPPLlSbdgfKAb6QqCFt5bo5VFZ50O3FFzsw4rnkqjwT6D8Qcoo9nshYKM7Mg==",
 					"requires": {
-						"bson": "^4.6.1",
-						"denque": "^2.0.1",
-						"mongodb-connection-string-url": "^2.4.1",
+						"@aws-sdk/credential-providers": "^3.186.0",
+						"bson": "^4.7.0",
+						"mongodb-connection-string-url": "^2.5.4",
 						"saslprep": "^1.0.3",
-						"socks": "^2.6.1"
+						"socks": "^2.7.1"
 					}
 				},
 				"ms": {
-					"version": "2.1.2"
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
 				}
 			}
 		},
@@ -57925,22 +59931,22 @@
 			}
 		},
 		"mpath": {
-			"version": "0.8.4",
-			"resolved": "https://registry.npmjs.org/mpath/-/mpath-0.8.4.tgz",
-			"integrity": "sha512-DTxNZomBcTWlrMW76jy1wvV37X/cNNxPW1y2Jzd4DZkAaC5ZGsm8bfGfNOthcDuRJujXLqiuS6o3Tpy0JEoh7g=="
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+			"integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew=="
 		},
 		"mquery": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/mquery/-/mquery-4.0.2.tgz",
-			"integrity": "sha512-oAVF0Nil1mT3rxty6Zln4YiD6x6QsUWYz927jZzjMxOK2aqmhEz5JQ7xmrKK7xRFA2dwV+YaOpKU/S+vfNqKxA==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/mquery/-/mquery-4.0.3.tgz",
+			"integrity": "sha512-J5heI+P08I6VJ2Ky3+33IpCdAvlYGTSUjwTPxkAr8i8EoduPMBX2OY/wa3IKZIQl7MU4SbFk8ndgSKyB/cl1zA==",
 			"requires": {
 				"debug": "4.x"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.3.3",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-					"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+					"version": "4.3.4",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 					"requires": {
 						"ms": "2.1.2"
 					}
@@ -59027,9 +61033,9 @@
 			}
 		},
 		"passport-local-mongoose": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/passport-local-mongoose/-/passport-local-mongoose-6.1.0.tgz",
-			"integrity": "sha512-kxRDejpBXoPmWau1RCrmEeNYEXGG9ec4aDYjd0pFAHIEAzZ0RXKn581ISfjpHZ1zZLoCCM2pWUo4SfGHNJNwnw==",
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/passport-local-mongoose/-/passport-local-mongoose-7.1.2.tgz",
+			"integrity": "sha512-hNLIKi/6IhElr/PhOze8wLDh7T4+ZYhc8GFWYApLgG7FrjI55tuGZELPtsUBqODz77OwlUUf+ngPgHN09zxGLg==",
 			"requires": {
 				"generaterr": "^1.5.0",
 				"passport-local": "^1.0.0",
@@ -60445,7 +62451,7 @@
 				"jest": "26.6.0",
 				"jest-environment-node": "26.6.2",
 				"mongodb-memory-server": "8.3.0",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"nock": "13.0.5",
 				"nodemon": "2.0.6",
 				"prettier": "2.2.1",
@@ -62744,7 +64750,7 @@
 				"jest": "26.6.0",
 				"mongodb": "3.6.3",
 				"mongodb-memory-server": "7.4.1",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"nock": "13.0.5",
 				"nodemon": "2.0.6",
 				"request": "2.88.2",
@@ -63624,7 +65630,7 @@
 				"eslint-plugin-node": "11.1.0",
 				"express": "4.16.3",
 				"mocha": "9.1.1",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"nconf": "0.10.0",
 				"nodemon": "^2.0.4",
 				"sinon": "^7.2.4",
@@ -63839,13 +65845,12 @@
 				"eslint-plugin-jest": "24.1.3",
 				"express": "4.17.1",
 				"jest": "26.6.0",
-				"jest-environment-node": "^26.6.2",
 				"jsonwebtoken": "8.5.1",
 				"lru-cache": "6.0.0",
 				"moment": "2.29.1",
 				"mongodb": "3.6.3",
 				"mongodb-memory-server": "7.4.0",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"morgan": "1.10.0",
 				"nock": "13.0.5",
 				"node-fetch": "2.6.1",
@@ -63912,20 +65917,6 @@
 				"isarray": {
 					"version": "1.0.0",
 					"dev": true
-				},
-				"jest-environment-node": {
-					"version": "26.6.2",
-					"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.6.2.tgz",
-					"integrity": "sha512-zhtMio3Exty18dy8ee8eJ9kjnRyZC1N4C1Nt/VShN1apyXc8rWGtJ9lI7vqiWcyyXS4BVSEn9lxAM2D+07/Tag==",
-					"dev": true,
-					"requires": {
-						"@jest/environment": "^26.6.2",
-						"@jest/fake-timers": "^26.6.2",
-						"@jest/types": "^26.6.2",
-						"@types/node": "*",
-						"jest-mock": "^26.6.2",
-						"jest-util": "^26.6.2"
-					}
 				},
 				"mongodb": {
 					"version": "3.6.3",
@@ -64239,9 +66230,9 @@
 			}
 		},
 		"sift": {
-			"version": "13.5.2",
-			"resolved": "https://registry.npmjs.org/sift/-/sift-13.5.2.tgz",
-			"integrity": "sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA=="
+			"version": "16.0.1",
+			"resolved": "https://registry.npmjs.org/sift/-/sift-16.0.1.tgz",
+			"integrity": "sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ=="
 		},
 		"signal-exit": {
 			"version": "3.0.4",
@@ -64524,7 +66515,7 @@
 				"koa2-swagger-ui": "5.1.0",
 				"lodash": "4.17.21",
 				"mocha": "9.1.1",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"nock": "10.0.6",
 				"supertest": "4.0.2",
 				"ts-node": "10.5.0",
@@ -64703,12 +66694,19 @@
 			}
 		},
 		"socks": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
-			"integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+			"integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
 			"requires": {
-				"ip": "^1.1.5",
+				"ip": "^2.0.0",
 				"smart-buffer": "^4.2.0"
+			},
+			"dependencies": {
+				"ip": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+					"integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
+				}
 			}
 		},
 		"sorted-array-functions": {
@@ -65142,6 +67140,12 @@
 		"strip-json-comments": {
 			"version": "3.1.1",
 			"dev": true
+		},
+		"strnum": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+			"integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+			"optional": true
 		},
 		"style-loader": {
 			"version": "3.3.1",
@@ -65581,7 +67585,7 @@
 				"mongod": "^2.0.0",
 				"mongodb": "^3.5.9",
 				"mongodb-memory-server": "7.4.1",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"nock": "^13.0.2",
 				"nodemon": "^2.0.4",
 				"path": "^0.12.7",
@@ -66215,7 +68219,7 @@
 		},
 		"tslib": {
 			"version": "2.3.1",
-			"dev": true
+			"devOptional": true
 		},
 		"tsscmp": {
 			"version": "1.0.6"
@@ -66760,7 +68764,7 @@
 				"eslint-plugin-node": "11.1.0",
 				"express": "4.17.1",
 				"mocha": "9.1.1",
-				"mongoose": "6.2.1",
+				"mongoose": "6.10.3",
 				"node-fetch": "2.6.5",
 				"nodemon": "2.0.4",
 				"sinon": "9.0.2",

--- a/services/analytics-service/package.json
+++ b/services/analytics-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analytics-service",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Stores provenance events and other analytics related data.",
   "main": "index.js",
   "scripts": {
@@ -25,7 +25,7 @@
     "dayjs": "^1.11.3",
     "dayjs-plugin-utc": "^0.1.2",
     "express": "^4.17.1",
-    "mongoose": "6.2.1",
+    "mongoose": "6.10.3",
     "node-fetch": "^2.6.6",
     "node-schedule": "^2.1.0",
     "qs": "^6.10.3",

--- a/services/app-directory/package.json
+++ b/services/app-directory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app-directory",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "private": true,
   "description": "",
   "main": "index.js",
@@ -23,7 +23,7 @@
     "cors": "^2.8.5",
     "dotenv": "6.2.0",
     "express": "4.17.1",
-    "mongoose": "6.2.1",
+    "mongoose": "6.10.3",
     "morgan": "^1.9.1",
     "request": "2.88.0",
     "request-promise": "4.2.4",

--- a/services/audit-log/package.json
+++ b/services/audit-log/package.json
@@ -1,6 +1,6 @@
 {
   "name": "audit-log",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Stores and retrieves audit logging data.",
   "main": "index.js",
   "private": true,
@@ -24,7 +24,7 @@
     "dotenv": "^8.2.0",
     "express": "^4.16.3",
     "jsonwebtoken": "^8.3.0",
-    "mongoose": "6.2.1",
+    "mongoose": "6.10.3",
     "request": "^2.87.0",
     "request-promise": "^4.2.2",
     "swagger-ui-express": "^4.1.4",

--- a/services/component-orchestrator/package.json
+++ b/services/component-orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-orchestrator",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Resource coordinator",
   "main": "index.js",
   "scripts": {
@@ -29,7 +29,7 @@
     "JSONStream": "1.3.5",
     "lodash": "4.17.21",
     "lru-cache": "6.0.0",
-    "mongoose": "6.2.1",
+    "mongoose": "6.10.3",
     "node-fetch": "2.6.1",
     "rabbitmq-stats": "1.2.3",
     "request": "2.88.2",

--- a/services/data-hub/package.json
+++ b/services/data-hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "data-hub",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Data hub",
   "main": "dist/index.js",
   "directories": {
@@ -59,7 +59,7 @@
     "koa-router": "10.0.0",
     "koa2-swagger-ui": "5.1.0",
     "lodash": "4.17.21",
-    "mongoose": "6.2.1",
+    "mongoose": "6.10.3",
     "notation": "2.0.0"
   }
 }

--- a/services/dispatcher-service/package.json
+++ b/services/dispatcher-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dispatcher-service",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Transfers data between flows",
   "main": "index.js",
   "scripts": {
@@ -23,7 +23,7 @@
     "dotenv": "^6.2.0",
     "express": "^4.16.3",
     "lodash": "4.17.21",
-    "mongoose": "6.2.1",
+    "mongoose": "6.10.3",
     "request": "2.88.2",
     "request-promise": "4.2.6",
     "swagger-ui-express": "^3.0.8"

--- a/services/flow-repository/package.json
+++ b/services/flow-repository/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-repository",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Stores and manages integration flows.",
   "main": "index.js",
   "scripts": {
@@ -23,7 +23,7 @@
     "cors": "^2.8.5",
     "cronstrue": "^1.94.0",
     "express": "^4.17.1",
-    "mongoose": "6.2.1",
+    "mongoose": "6.10.3",
     "request": "^2.87.0",
     "request-promise": "^4.2.5",
     "swagger-ui-express": "^4.1.4"

--- a/services/governance-service/package.json
+++ b/services/governance-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "governance-service",
-  "version": "1.5.5",
+  "version": "1.6.0",
   "description": "Stores provenance events and other governance related data.",
   "main": "index.js",
   "scripts": {
@@ -25,7 +25,7 @@
     "dot-prop": "^6.0.1",
     "express": "^4.17.1",
     "node-fetch": "^2.6.6",
-    "mongoose": "6.2.1",
+    "mongoose": "6.10.3",
     "request": "^2.87.0",
     "request-promise": "^4.2.5",
     "swagger-ui-express": "^4.1.4"

--- a/services/iam/package.json
+++ b/services/iam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iam",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Identity and Access Management Service",
   "main": "index.js",
   "scripts": {
@@ -44,13 +44,13 @@
     "lodash": "4.17.21",
     "moment": "2.28.0",
     "mongodb": "3.6.2",
-    "mongoose": "6.2.1",
+    "mongoose": "6.10.3",
     "ms": "2.1.2",
     "node-jose": "2.0.0",
     "oidc-provider": "5.5.3",
     "passport": "0.4.1",
     "passport-jwt": "4.0.0",
-    "passport-local-mongoose": "6.1.0",
+    "passport-local-mongoose": "7.1.2",
     "pug": "3.0.2",
     "request": "2.88.2",
     "request-promise": "4.2.6",

--- a/services/ils/package.json
+++ b/services/ils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ils",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Integration Layer Service",
   "main": "index.js",
   "scripts": {
@@ -24,7 +24,7 @@
     "dotenv": "^8.2.0",
     "express": "^4.16.3",
     "generate-schema": "^2.6.0",
-    "mongoose": "6.2.1",
+    "mongoose": "6.10.3",
     "request": "2.88.2",
     "request-promise": "4.2.6",
     "swagger-ui-express": "^4.1.4"

--- a/services/meta-data-repository/package.json
+++ b/services/meta-data-repository/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meta-data-repository",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "TBD",
   "main": "index.js",
   "author": "Basaas GmbH",
@@ -29,7 +29,7 @@
     "jszip": "3.2.2",
     "mkdirp": "1.0.4",
     "moment": "2.24.0",
-    "mongoose": "6.2.1",
+    "mongoose": "6.10.3",
     "morgan": "1.9.1",
     "multer": "1.4.2",
     "qs": "6.10.1",

--- a/services/rds/package.json
+++ b/services/rds/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rds",
   "description": "Raw Data Storage",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "main": "index.js",
   "author": "Basaas GmbH",
   "license": "Apache-2.0",
@@ -33,7 +33,7 @@
     "bunyan": "1.8.14",
     "cors": "2.8.5",
     "express": "4.17.1",
-    "mongoose": "6.2.1",
+    "mongoose": "6.10.3",
     "body-parser": "1.19.0",
     "isomorphic-fetch": "3.0.0",
     "swagger-ui-express": "4.1.5",

--- a/services/reports-analytics/package.json
+++ b/services/reports-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reports-analytics",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "TBD",
   "main": "index.js",
   "author": "Basaas GmbH",
@@ -27,7 +27,7 @@
     "dotenv": "8.2.0",
     "express": "4.17.1",
     "influx": "5.6.3",
-    "mongoose": "6.2.1",
+    "mongoose": "6.10.3",
     "request": "2.88.2"
   },
   "devDependencies": {

--- a/services/scheduler/package.json
+++ b/services/scheduler/package.json
@@ -2,7 +2,7 @@
   "name": "scheduler",
   "description": "Scheduler",
   "private": true,
-  "version": "0.3.2",
+  "version": "0.4.0",
   "author": "Open Integration Hub",
   "engines": {
     "node": ">=12"
@@ -25,7 +25,7 @@
     "backend-commons-lib": "*",
     "cron-parser": "2.7.3",
     "express": "4.16.3",
-    "mongoose": "6.2.1",
+    "mongoose": "6.10.3",
     "nconf": "0.10.0",
     "uuid": "3.3.2"
   },

--- a/services/secret-service/package.json
+++ b/services/secret-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secret-service",
-  "version": "2.9.2",
+  "version": "2.10.0",
   "description": "Service to manage Keys/Tokens of external services",
   "main": "index.js",
   "author": "Basaas GmbH",
@@ -28,7 +28,7 @@
     "jsonwebtoken": "8.5.1",
     "lru-cache": "6.0.0",
     "moment": "2.29.1",
-    "mongoose": "6.2.1",
+    "mongoose": "6.10.3",
     "morgan": "1.10.0",
     "node-fetch": "2.6.1",
     "oauth": "0.9.15",

--- a/services/snapshots-service/package.json
+++ b/services/snapshots-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snapshots-service",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "Service for managing flow snapshots",
   "main": "dist/index.js",
   "directories": {
@@ -52,6 +52,6 @@
     "koa-router": "7.4.0",
     "koa2-swagger-ui": "5.1.0",
     "lodash": "4.17.21",
-    "mongoose": "6.2.1"
+    "mongoose": "6.10.3"
   }
 }

--- a/services/template-repository/package.json
+++ b/services/template-repository/package.json
@@ -1,6 +1,6 @@
 {
   "name": "template-repository",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "Holds reproducible templates which can be used to generate flows.",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
     "cronstrue": "^1.94.0",
     "express": "^4.17.1",
     "lodash": "4.17.21",
-    "mongoose": "6.2.1",
+    "mongoose": "6.10.3",
     "request": "^2.87.0",
     "request-promise": "^4.2.5",
     "swagger-ui-express": "^4.1.4"

--- a/services/template-repository/test/test.js
+++ b/services/template-repository/test/test.js
@@ -259,8 +259,8 @@ describe('Template Validation', () => {
       });
     expect(res.status).toEqual(400);
     expect(res.body.errors).toHaveLength(3);
-    expect(res.body.errors[0].message).stringContaining('Cast to ObjectId failed for value "IncorrectSecret" (type string) at path "credentials_id"');
-    expect(res.body.errors[1].message).stringContaining('Cast to ObjectId failed for value "abc" (type string) at path "componentId"');
+    expect(res.body.errors[0].message).toEqual(expect.stringContaining('Cast to ObjectId failed for value "IncorrectSecret" (type string) at path "credentials_id"'));
+    expect(res.body.errors[1].message).toEqual(expect.stringContaining('Cast to ObjectId failed for value "abc" (type string) at path "componentId"'));
     expect(res.body.errors[2].message).toEqual('Flow Templates with more than one node require edges.');
   });
 

--- a/services/template-repository/test/test.js
+++ b/services/template-repository/test/test.js
@@ -259,8 +259,8 @@ describe('Template Validation', () => {
       });
     expect(res.status).toEqual(400);
     expect(res.body.errors).toHaveLength(3);
-    expect(res.body.errors[0].message).toMatch(/Cast to ObjectId failed for value "IncorrectSecret" (type string) at path "credentials_id"/);
-    expect(res.body.errors[1].message).toEqual(/Cast to ObjectId failed for value "abc" (type string) at path "componentId"/);
+    expect(res.body.errors[0].message).stringContaining('Cast to ObjectId failed for value "IncorrectSecret" (type string) at path "credentials_id"');
+    expect(res.body.errors[1].message).stringContaining('Cast to ObjectId failed for value "abc" (type string) at path "componentId"');
     expect(res.body.errors[2].message).toEqual('Flow Templates with more than one node require edges.');
   });
 

--- a/services/template-repository/test/test.js
+++ b/services/template-repository/test/test.js
@@ -259,8 +259,8 @@ describe('Template Validation', () => {
       });
     expect(res.status).toEqual(400);
     expect(res.body.errors).toHaveLength(3);
-    expect(res.body.errors[0].message).toEqual('Cast to ObjectId failed for value "IncorrectSecret" (type string) at path "credentials_id"');
-    expect(res.body.errors[1].message).toEqual('Cast to ObjectId failed for value "abc" (type string) at path "componentId"');
+    expect(res.body.errors[0].message).toMatch(/Cast to ObjectId failed for value "IncorrectSecret" (type string) at path "credentials_id"/);
+    expect(res.body.errors[1].message).toEqual(/Cast to ObjectId failed for value "abc" (type string) at path "componentId"/);
     expect(res.body.errors[2].message).toEqual('Flow Templates with more than one node require edges.');
   });
 

--- a/services/webhooks/package.json
+++ b/services/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webhooks",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "OIH Incoming Webhooks Service",
   "main": "index.js",
   "scripts": {
@@ -26,7 +26,7 @@
     "bunyan": "^1.8.14",
     "bunyan-format": "^0.2.1",
     "express": "4.17.1",
-    "mongoose": "6.2.1",
+    "mongoose": "6.10.3",
     "node-fetch": "2.6.5"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR updates the mongoose library across all services to support Mongo 6.x when it is transitioned in the Mongo Atlas cloud databases.

Additionally, the Minikube Development environment is setup to deploy services from source, since "npm workspaces" requires the workspace name rather than the previous usage of the workspace location from "yarn."