### PR TITLE
Added workaround to kubernetes client lacking permissions to read

### DIFF
--- a/services/component-repository/k8s/deployment/deployment.yaml
+++ b/services/component-repository/k8s/deployment/deployment.yaml
@@ -17,6 +17,8 @@ spec:
         app: component-repository
     spec:
       restartPolicy: Always
+      securityContext:
+        fsGroup: 65534
       terminationGracePeriodSeconds: 30
       containers:
       - name: component-repository


### PR DESCRIPTION
See also: https://github.com/rancher/fleet/issues/790

**What has changed?**

- Added fsGroup: 65534 security context to component orchestrator k8s spec
- Fixes an issue where orchestrator's kubernetes client could not read service account data and would crash loop