### PR TITLE
Secret service SESSION_AUTH type, add FORM_AUTH request type

### DIFF
--- a/services/secret-service/doc/openapi.json
+++ b/services/secret-service/doc/openapi.json
@@ -777,6 +777,9 @@
           "tokenPath": {
             "type": "string"
           },
+          "expirationPath": {
+            "type": "string"
+          },
           "endpoints": {
             "type": "object",
             "required": ["auth"],
@@ -946,7 +949,7 @@
           },
           "authType": {
             "type": "string",
-            "enum": ["HEADER_AUTH", "BODY_AUTH", "PARAMS_AUTH"]
+            "enum": ["HEADER_AUTH", "BODY_AUTH", "PARAMS_AUTH", "FORM_AUTH"]
           },
           "url": {
             "type": "string"

--- a/services/secret-service/src/constant/index.js
+++ b/services/secret-service/src/constant/index.js
@@ -19,6 +19,7 @@ module.exports = {
         HEADER_AUTH: 'HEADER_AUTH',
         BODY_AUTH: 'BODY_AUTH',
         PARAMS_AUTH: 'PARAMS_AUTH',
+        FORM_AUTH: 'FORM_AUTH',
     },
     ENTITY_TYPE: {
         USER: 'USER',

--- a/services/secret-service/src/dao/secret.js
+++ b/services/secret-service/src/dao/secret.js
@@ -130,7 +130,8 @@ const refresh = (secret, key, iter = 0) => new Promise(async (resolve, reject) =
                         _secret.value.expires = moment().add(resp.expires_in, 'seconds').toISOString();
                         break;
                     case SESSION_AUTH:
-                        _secret.value.accessToken = resp;
+                        _secret.value.accessToken = resp.access_token;
+                        _secret.value.expires = resp.expires_in ? moment().add(resp.expires_in, 'seconds').toISOString() : null;
                         break;
                     default:
                         break;

--- a/services/secret-service/src/model/AuthClient/index.js
+++ b/services/secret-service/src/model/AuthClient/index.js
@@ -134,6 +134,7 @@ module.exports = {
                 required: true,
             },
             tokenPath: String,
+            expirationPath: String,
             endpoints: {
                 auth: {
                     type: requestConfig,

--- a/services/secret-service/src/model/Secret/index.js
+++ b/services/secret-service/src/model/Secret/index.js
@@ -101,6 +101,7 @@ module.exports = {
                 },
             },
             accessToken: String,
+            expires: String,
             inputFields: Schema.Types.Mixed, // TODO: Define discriminated Values based on user fields from the Auth Client
         },
     })),


### PR DESCRIPTION
**What has changed?**
- Add FORM_AUTH request type. Previously the body was only sent with the `application/json` content-type. Now the request fields can be submitted as the `application/x-www-form-urlencoded` content-type as well.
- Add expires property configuration. This is to enable the token to be reused if an expiration is present in the response.  This will reduce API call latency and potentially overwhelming the external API.
- Used MS Graph API with a client_credential grant type to test The FORM_AUTH will submit the request fields as application/x-www-form-urlencoded type. The docker image used to test is blendededge/secret-service:22.2.2

**Does a specific change require especially careful review?**

This slightly changes the secret service API by adding an optional expirationPath configuration. Also the schema for SESSION_AUTH needed to change to store the optional `expires` date time. Previously the refreshToken function returned only the token string which was stored in the secret. It now returns an object with the token and expiration date time specific to the SESSION_AUTH type

**What is still open or a known issue?**
N/A

**Release Notes**

- Secret service: Updated the SESSION_AUTH type with the ability to submit session credentials as `application/x-www-form-urlencoded` form data instead of only `application/json`