### PR TITLE
Temporarily disabled automatic deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,7 +262,7 @@ workflows:
           requires:
             - test
           filters: *only_master_filter
-      - deploy:
-          requires:
-            - build
-          filters: *only_master_filter
+#      - deploy:
+#          requires:
+#            - build
+#          filters: *only_master_filter


### PR DESCRIPTION
As the kubernetes authentification plugin has changed, automatic deployment via CircleCI currently always fails. This disables the deployment step until the issue with the auth plugin is resolved.

Actual functionality of OIH itself is not affected.
