### PR TITLE
Include source information in payload from webhooks and scheduler

### DIFF
--- a/lib/webhooks/spec/http-api.spec.js
+++ b/lib/webhooks/spec/http-api.spec.js
@@ -118,7 +118,13 @@ describe('HttpApi', () => {
                     'query',
                     'url'
                 ]);
-                expect(msgArg.metadata).to.deep.equal({});
+                expect(msgArg.metadata).to.deep.equal({
+                    source: {
+                        name: 'webhooks',
+                        type: 'webhook',
+                        externalExecId: 'semen-semenich'
+                    }
+                });
                 expect(msgArg.method).to.equal('GET');
                 expect(msgArg.originalUrl).to.equal('/hook/123?a=b');
                 expect(msgArg.pathSuffix).to.equal('/hook/123');
@@ -212,7 +218,13 @@ describe('HttpApi', () => {
                     'query',
                     'url'
                 ]);
-                expect(msgArg.metadata).to.deep.equal({});
+                expect(msgArg.metadata).to.deep.equal({
+                    source: {
+                        name: 'webhooks',
+                        type: 'webhook',
+                        externalExecId: 'semen-semenich'
+                    }
+                });
                 expect(msgArg.method).to.equal('POST');
                 expect(msgArg.originalUrl).to.equal('/hook/123?a=b');
                 expect(msgArg.pathSuffix).to.equal('/hook/123');

--- a/lib/webhooks/spec/request-handlers/get.spec.js
+++ b/lib/webhooks/spec/request-handlers/get.spec.js
@@ -94,7 +94,13 @@ describe('Get Request Handler', () => {
                     headers: {
                         some: 'header'
                     },
-                    metadata: {},
+                    metadata: {
+                        source: {
+                            name: 'webhooks',
+                            type: 'webhook',
+                            externalExecId: 'request-id'
+                        }
+                    },
                     method: 'GET',
                     originalUrl: '/hooks/test-id/foo/bar/baz',
                     params: {},
@@ -274,7 +280,13 @@ describe('Get Request Handler', () => {
                     'query',
                     'url'
                 ]);
-                expect(msg.metadata).to.deep.equal({});
+                expect(msg.metadata).to.deep.equal({
+                    source: {
+                        name: 'webhooks',
+                        type: 'webhook',
+                        externalExecId: 'my-req-id'
+                    }
+                });
                 expect(msg.method).to.equal('GET');
                 expect(msg.originalUrl).to.equal('/?a=b');
                 expect(msg.pathSuffix).to.equal('/');

--- a/lib/webhooks/spec/request-handlers/post.spec.js
+++ b/lib/webhooks/spec/request-handlers/post.spec.js
@@ -97,7 +97,13 @@ describe('Post Request Handler', () => {
                     headers: {
                         some: 'header'
                     },
-                    metadata: {},
+                    metadata: {
+                        source: {
+                            name: 'webhooks',
+                            type: 'webhook',
+                            externalExecId: 'request-id'
+                        }
+                    },
                     method: 'POST',
                     originalUrl: '/hooks/test-id/foo/bar/baz',
                     params: {},
@@ -277,7 +283,13 @@ describe('Post Request Handler', () => {
                     'query',
                     'url'
                 ]);
-                expect(msg.metadata).to.deep.equal({});
+                expect(msg.metadata).to.deep.equal({
+                    source: {
+                        name: 'webhooks',
+                        type: 'webhook',
+                        externalExecId: 'my-req-id'
+                    }
+                });
                 expect(msg.method).to.equal('POST');
                 expect(msg.originalUrl).to.equal('/?a=b');
                 expect(msg.pathSuffix).to.equal('/');

--- a/lib/webhooks/src/request-handlers/post.js
+++ b/lib/webhooks/src/request-handlers/post.js
@@ -83,6 +83,7 @@ class PostHandler extends BaseHandler {
         log.trace('Creating webhook msg from request');
 
         const msg = newEmptyMessage();
+        msg.metadata.externalExecId = this.getRequestId();
 
         _.each(REQUEST_FIELDS, (key) => {
             if (key === 'body') {

--- a/lib/webhooks/src/request-handlers/post.js
+++ b/lib/webhooks/src/request-handlers/post.js
@@ -83,10 +83,10 @@ class PostHandler extends BaseHandler {
         log.trace('Creating webhook msg from request');
 
         const msg = newEmptyMessage();
-        msg.metadata.externalExecId = this.getRequestId();
         msg.metadata.source = {
-            id: 'webhooks',
-            type: 'webhook'
+            name: 'webhooks',
+            type: 'webhook',
+            externalExecId: this.getRequestId()
         };
 
         _.each(REQUEST_FIELDS, (key) => {

--- a/lib/webhooks/src/request-handlers/post.js
+++ b/lib/webhooks/src/request-handlers/post.js
@@ -84,6 +84,10 @@ class PostHandler extends BaseHandler {
 
         const msg = newEmptyMessage();
         msg.metadata.externalExecId = this.getRequestId();
+        msg.metadata.source = {
+            id: 'webhooks',
+            type: 'webhook'
+        };
 
         _.each(REQUEST_FIELDS, (key) => {
             if (key === 'body') {

--- a/services/scheduler/src/SchedulePublisher.js
+++ b/services/scheduler/src/SchedulePublisher.js
@@ -24,10 +24,10 @@ class OIH_SchedulePublisher extends SchedulePublisher {
           },
           metadata: {
             source: {
-              id: 'scheduler',
+              name: 'scheduler',
               type: 'scheduler',
+              externalExecId: generateRequestId(),
             },
-            externalExecId: generateRequestId(),
           },
         },
       },

--- a/services/scheduler/src/SchedulePublisher.js
+++ b/services/scheduler/src/SchedulePublisher.js
@@ -1,5 +1,6 @@
 const { SchedulePublisher } = require('@openintegrationhub/scheduler');
 const { Event } = require('@openintegrationhub/event-bus');
+const cronParser = require('cron-parser');
 
 class OIH_SchedulePublisher extends SchedulePublisher {
   constructor({ eventBus }) {
@@ -7,6 +8,8 @@ class OIH_SchedulePublisher extends SchedulePublisher {
     this._eventBus = eventBus;
   }
   async scheduleFlow(flow) {
+    const interval = cronParser.parseExpression(flow.cron);
+    const nextSheduledTimestamp = interval.next();
     const event = new Event({
       headers: {
         name: 'flow.execute',
@@ -14,10 +17,32 @@ class OIH_SchedulePublisher extends SchedulePublisher {
       },
       payload: {
         flow,
+        msg: {
+          data: {
+            sheduledTimestamp: new Date().toISOString(),
+            nextSheduledTimestamp,
+          },
+          metadata: {
+            source: {
+              id: 'scheduler',
+              type: 'scheduler',
+            },
+            externalExecId: generateRequestId(),
+          },
+        },
       },
     });
     this._eventBus.publish(event);
   }
+}
+
+function generateRequestId() {
+  // NOTE the result should be in the same format as provided by proxy in from of this server (nginx)
+  const numbers = [];
+  for (let i = 0; i < 32; i++) {
+      numbers[i] = Math.floor(Math.random() * 16).toString(16);
+  }
+  return numbers.join('');
 }
 
 module.exports = OIH_SchedulePublisher;


### PR DESCRIPTION
**What has changed?**

- Webhook requestId in the response object always passed into flow
- Scheduler always passes unique ID the same as the webhook service
- Add source metadata to webhhooks and scheduler payload
- Add scheduler related data to the scheduler payload

**Does a specific change require especially careful review?**

N/A

**What is still open or a known issue?**
N/A

**Release Notes**
Same as what has changed