### PR TITLE
Publish component messages to the RabbitMQ exchange topic

### DIFF
--- a/lib/component-orchestrator/package.json
+++ b/lib/component-orchestrator/package.json
@@ -13,8 +13,10 @@
   "license": "APL-2.0",
   "dependencies": {
     "@openintegrationhub/event-bus": "*",
+    "amqplib": "^0.10.3",
     "jsonwebtoken": "8.5.1",
     "lodash": "4.17.21",
+    "promise-toolbox": "^0.21.0",
     "uuid": "8.3.0"
   },
   "devDependencies": {

--- a/lib/component-orchestrator/src/ComponentOrchestrator.js
+++ b/lib/component-orchestrator/src/ComponentOrchestrator.js
@@ -1,6 +1,7 @@
 const { Event } = require('@openintegrationhub/event-bus');
 const { v1, v4 } = require('uuid');
 const jwt = require('jsonwebtoken');
+const {Amqp} = require('./amqp');
 
 const orchestratorId = `orchestrator-${v1()}`
 
@@ -22,6 +23,7 @@ class ComponentOrchestrator {
     constructor({
         config,
         channel,
+        publishChannel,
         logger,
         queuesManager,
         queueCreator,
@@ -38,6 +40,8 @@ class ComponentOrchestrator {
         this._logger = logger.child({ service: 'ComponentOrchestrator' });
         this._queuesManager = queuesManager;
         this._queueCreator = queueCreator;
+        this._publishChannel = publishChannel;
+        this._amqp = new Amqp(publishChannel, config, logger);
         this._flowsDao = flowsDao;
         this._flowStateDao = flowStateDao;
         this._componentsDao = componentsDao;
@@ -49,7 +53,6 @@ class ComponentOrchestrator {
     }
 
     async start() {
-
         // create backchannel exchange, queues and bindings
         await this._queuesManager.setupBackchannel();
 
@@ -544,7 +547,7 @@ class ComponentOrchestrator {
             config = this._queueCreator.getAmqpStepConfig(flow, stepId);
         }
 
-        const { messagesQueue, exchangeName, deadLetterRoutingKey } = config;
+        const { messagesQueue, exchangeName, deadLetterRoutingKey, inputRoutingKey } = config;
 
         await this._queueCreator.assertMessagesQueue(
             messagesQueue,
@@ -552,14 +555,7 @@ class ComponentOrchestrator {
             deadLetterRoutingKey
         );
 
-        await this._channel.sendToQueue(
-            messagesQueue,
-            Buffer.from(JSON.stringify(newMessage)),
-            {
-                contentType: 'text/json',
-                headers: record,
-            }
-        );
+        await this._amqp.sendComponentInputMessage(exchangeName, inputRoutingKey, newMessage, record);
     }
 
     async executeFlow({ flow, msg = {} /*,  msgOpts = {} */ } /* , { type } */) {

--- a/lib/component-orchestrator/src/amqp.js
+++ b/lib/component-orchestrator/src/amqp.js
@@ -20,11 +20,12 @@ class Amqp {
         return this.publishMessage(exchangeName, routingKey, buffer, options, 0);
     }
 
-    async publishMessage(exchangeName, routingKey, payloadBuffer, options, iteration) {
+    async publishMessage(exchangeName, routingKey, payloadBuffer, options = { headers: {} }, iteration) {
         const { settings } = this;
         if (iteration) {
             options.headers.retry = iteration; // eslint-disable-line no-param-reassign
         }
+        options.persistent = true; // eslint-disable-line no-param-reassign
 
         this.log.debug('Current memory usage: %s Mb', process.memoryUsage().heapUsed / 1048576);
         this.log.trace('Pushing to exchange=%s, routingKey=%s, messageSize=%d, options=%j, iteration=%d',

--- a/lib/component-orchestrator/src/amqp.js
+++ b/lib/component-orchestrator/src/amqp.js
@@ -1,0 +1,125 @@
+
+/* eslint consistent-return: 0 */ // --> OFF
+/* eslint no-underscore-dangle: 0 */ // --> OFF
+/* eslint no-use-before-define: 0 */ // --> OFF
+/* eslint consistent-this: 0 */
+
+const { IllegalOperationError } = require('amqplib/lib/error');
+const { fromEvent, timeout } = require('promise-toolbox');
+
+class Amqp {
+    constructor(channel, settings, logger) {
+        this.publishChannel = channel;
+        this.settings = settings;
+        this.log = logger;
+    }
+
+    async sendToExchange(exchangeName, routingKey, payload, options) {
+        const buffer = Buffer.from(payload);
+
+        return this.publishMessage(exchangeName, routingKey, buffer, options, 0);
+    }
+
+    async publishMessage(exchangeName, routingKey, payloadBuffer, options, iteration) {
+        const { settings } = this;
+        if (iteration) {
+            options.headers.retry = iteration; // eslint-disable-line no-param-reassign
+        }
+
+        this.log.debug('Current memory usage: %s Mb', process.memoryUsage().heapUsed / 1048576);
+        this.log.trace('Pushing to exchange=%s, routingKey=%s, messageSize=%d, options=%j, iteration=%d',
+            exchangeName, routingKey, payloadBuffer.length, options, iteration);
+        try {
+            const result = await this._promisifiedPublish(
+                exchangeName, routingKey, payloadBuffer, options
+            );
+            if (!result) {
+                this.log.warn('Buffer full when publishing a message to '
+          + 'exchange=%s with routingKey=%s', exchangeName, routingKey);
+            }
+            return result;
+        } catch (error) {
+            if (error instanceof IllegalOperationError) {
+                this.log.error(error, `Failed on publishing ${options.headers.messageId} message to MQ`);
+                // throw new Error(`Failed on publishing ${options.headers.messageId} message to MQ: ${error}`);
+                this.log.error(JSON.stringify({ exchangeName, routingKey, payloadBuffer, options, iteration }));
+            }
+            this.log.error(error, 'Failed on publishing message to queue');
+            const delay = this._getDelay(
+                settings.AMQP_PUBLISH_RETRY_DELAY,
+                settings.AMQP_PUBLISH_MAX_RETRY_DELAY,
+                iteration
+            );
+            await this._sleep(delay);
+            iteration += 1; // eslint-disable-line no-param-reassign
+            if (iteration < settings.AMQP_PUBLISH_RETRY_ATTEMPTS) {
+                return this.publishMessage(exchangeName, routingKey, payloadBuffer, options, iteration);
+            }
+
+            // throw new Error(`Failed on publishing ${options.headers.messageId} message to MQ: ${error}`);
+            this.log.error(`Failed on publishing ${options.headers.messageId} message to MQ: ${error}`);
+            this.log.error(JSON.stringify({ exchangeName, routingKey, payloadBuffer, options, iteration }));
+
+
+        }
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    _getDelay(defaultDelay, maxDelay, iteration) {
+        this.log.debug({ defaultDelay }, 'Current delay');
+        this.log.debug({ maxDelay }, 'Current delay');
+        // eslint-disable-next-line no-restricted-properties
+        const delay = Math.min(defaultDelay * Math.pow(2, iteration), maxDelay);
+        this.log.debug({ delay }, 'Calculated delay');
+        return delay;
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    async _sleep(time) {
+        await new Promise(resolve => setTimeout(resolve, time));
+    }
+
+    async _promisifiedPublish(exchangeName, routingKey, payloadBuffer, options) {
+        try {
+            let result;
+            const threshold = 10000;
+            const { publishChannel } = this;
+            const publishPromise = new Promise((resolve, reject) => {
+                result = publishChannel.publish(
+                    exchangeName, routingKey, payloadBuffer, options, (err, ok) => {
+                        err ? reject(err) : resolve(ok); // eslint-disable-line no-unused-expressions
+                    }
+                );
+            });
+
+            await publishPromise;
+            if (this.settings.PROCESS_AMQP_DRAIN && result === false) {
+                this.log.debug('Amqp buffer is full: waiting for drain event..');
+                let drained = true;
+                await timeout.call(fromEvent(this.publishChannel, 'drain'), threshold, () => {
+                    drained = false;
+                    this.log.error(`Drain event was not emitted after ${threshold / 1000} seconds, proceeding...`);
+                });
+                if (drained) {
+                    this.log.debug('Amqp buffer drained!');
+                }
+                result = true;
+            }
+
+            return result;
+        } catch (error) {
+            this.log.error(error);
+            throw error;
+        }
+    }
+
+    async sendComponentInputMessage(exchangeName, routingKey, data, headers) {
+        const payload = JSON.stringify(data);
+        const properties = {
+            contentType: 'text/json',
+            headers,
+        }
+        return this.sendToExchange(exchangeName, routingKey, payload, properties);
+    }
+}
+exports.Amqp = Amqp;

--- a/package-lock.json
+++ b/package-lock.json
@@ -345,8 +345,10 @@
 			"license": "APL-2.0",
 			"dependencies": {
 				"@openintegrationhub/event-bus": "*",
+				"amqplib": "^0.10.3",
 				"jsonwebtoken": "8.5.1",
 				"lodash": "4.17.21",
+				"promise-toolbox": "^0.21.0",
 				"uuid": "8.3.0"
 			},
 			"devDependencies": {
@@ -361,6 +363,20 @@
 			},
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"lib/component-orchestrator/node_modules/amqplib": {
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.3.tgz",
+			"integrity": "sha512-UHmuSa7n8vVW/a5HGh2nFPqAEr8+cD4dEZ6u9GjP91nHfr1a54RyAKyra7Sb5NH7NBKOUlyQSMXIp0qAixKexw==",
+			"dependencies": {
+				"@acuminous/bitsyntax": "^0.1.2",
+				"buffer-more-ints": "~1.0.0",
+				"readable-stream": "1.x >=1.1.9",
+				"url-parse": "~1.5.10"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"lib/component-orchestrator/node_modules/bunyan": {
@@ -399,6 +415,17 @@
 			},
 			"peerDependencies": {
 				"eslint": ">=5.16.0"
+			}
+		},
+		"lib/component-orchestrator/node_modules/promise-toolbox": {
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/promise-toolbox/-/promise-toolbox-0.21.0.tgz",
+			"integrity": "sha512-NV8aTmpwrZv+Iys54sSFOBx3tuVaOBvvrft5PNppnxy9xpU/akHbaWIril22AB22zaPgrgwKdD0KsrM0ptUtpg==",
+			"dependencies": {
+				"make-error": "^1.3.2"
+			},
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"lib/component-orchestrator/node_modules/sinon": {
@@ -1447,6 +1474,40 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/@acuminous/bitsyntax": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/@acuminous/bitsyntax/-/bitsyntax-0.1.2.tgz",
+			"integrity": "sha512-29lUK80d1muEQqiUsSo+3A0yP6CdspgC95EnKBMi22Xlwt79i/En4Vr67+cXhU+cZjbti3TgGGC5wy1stIywVQ==",
+			"dependencies": {
+				"buffer-more-ints": "~1.0.0",
+				"debug": "^4.3.4",
+				"safe-buffer": "~5.1.2"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/@acuminous/bitsyntax/node_modules/debug": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@acuminous/bitsyntax/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"node_modules/@alloc/quick-lru": {
 			"version": "5.2.0",
@@ -39155,6 +39216,7 @@
 				"@openintegrationhub/component-orchestrator": "*",
 				"@openintegrationhub/event-bus": "*",
 				"@openintegrationhub/iam-utils": "*",
+				"amqplib": "^0.10.3",
 				"backend-commons-lib": "*",
 				"basic-auth": "2.0.1",
 				"express": "4.17.1",
@@ -39164,6 +39226,7 @@
 				"lru-cache": "6.0.0",
 				"mongoose": "6.10.3",
 				"node-fetch": "2.6.1",
+				"promise-toolbox": "^0.21.0",
 				"rabbitmq-stats": "1.2.3",
 				"request": "2.88.2",
 				"uuid": "8.3.0"
@@ -39234,6 +39297,20 @@
 			},
 			"engines": {
 				"node": ">=0.4.0"
+			}
+		},
+		"services/component-orchestrator/node_modules/amqplib": {
+			"version": "0.10.3",
+			"resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.3.tgz",
+			"integrity": "sha512-UHmuSa7n8vVW/a5HGh2nFPqAEr8+cD4dEZ6u9GjP91nHfr1a54RyAKyra7Sb5NH7NBKOUlyQSMXIp0qAixKexw==",
+			"dependencies": {
+				"@acuminous/bitsyntax": "^0.1.2",
+				"buffer-more-ints": "~1.0.0",
+				"readable-stream": "1.x >=1.1.9",
+				"url-parse": "~1.5.10"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"services/component-orchestrator/node_modules/ansi-styles": {
@@ -39662,6 +39739,17 @@
 			},
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"services/component-orchestrator/node_modules/promise-toolbox": {
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/promise-toolbox/-/promise-toolbox-0.21.0.tgz",
+			"integrity": "sha512-NV8aTmpwrZv+Iys54sSFOBx3tuVaOBvvrft5PNppnxy9xpU/akHbaWIril22AB22zaPgrgwKdD0KsrM0ptUtpg==",
+			"dependencies": {
+				"make-error": "^1.3.2"
+			},
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"services/component-orchestrator/node_modules/qs": {
@@ -48966,6 +49054,31 @@
 			"integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
 			"dev": true
 		},
+		"@acuminous/bitsyntax": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/@acuminous/bitsyntax/-/bitsyntax-0.1.2.tgz",
+			"integrity": "sha512-29lUK80d1muEQqiUsSo+3A0yP6CdspgC95EnKBMi22Xlwt79i/En4Vr67+cXhU+cZjbti3TgGGC5wy1stIywVQ==",
+			"requires": {
+				"buffer-more-ints": "~1.0.0",
+				"debug": "^4.3.4",
+				"safe-buffer": "~5.1.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.4",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+				}
+			}
+		},
 		"@alloc/quick-lru": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
@@ -52226,6 +52339,7 @@
 			"version": "file:lib/component-orchestrator",
 			"requires": {
 				"@openintegrationhub/event-bus": "*",
+				"amqplib": "^0.10.3",
 				"bunyan": "1.8.14",
 				"chai": "4.2.0",
 				"eslint": "7.32.0",
@@ -52234,11 +52348,23 @@
 				"jsonwebtoken": "8.5.1",
 				"lodash": "4.17.21",
 				"mocha": "9.1.1",
+				"promise-toolbox": "^0.21.0",
 				"sinon": "9.0.3",
 				"sinon-chai": "3.5.0",
 				"uuid": "8.3.0"
 			},
 			"dependencies": {
+				"amqplib": {
+					"version": "0.10.3",
+					"resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.3.tgz",
+					"integrity": "sha512-UHmuSa7n8vVW/a5HGh2nFPqAEr8+cD4dEZ6u9GjP91nHfr1a54RyAKyra7Sb5NH7NBKOUlyQSMXIp0qAixKexw==",
+					"requires": {
+						"@acuminous/bitsyntax": "^0.1.2",
+						"buffer-more-ints": "~1.0.0",
+						"readable-stream": "1.x >=1.1.9",
+						"url-parse": "~1.5.10"
+					}
+				},
 				"bunyan": {
 					"version": "1.8.14",
 					"resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.14.tgz",
@@ -52263,6 +52389,14 @@
 						"minimatch": "^3.0.4",
 						"resolve": "^1.10.1",
 						"semver": "^6.1.0"
+					}
+				},
+				"promise-toolbox": {
+					"version": "0.21.0",
+					"resolved": "https://registry.npmjs.org/promise-toolbox/-/promise-toolbox-0.21.0.tgz",
+					"integrity": "sha512-NV8aTmpwrZv+Iys54sSFOBx3tuVaOBvvrft5PNppnxy9xpU/akHbaWIril22AB22zaPgrgwKdD0KsrM0ptUtpg==",
+					"requires": {
+						"make-error": "^1.3.2"
 					}
 				},
 				"sinon": {
@@ -58719,6 +58853,7 @@
 				"@openintegrationhub/component-orchestrator": "*",
 				"@openintegrationhub/event-bus": "*",
 				"@openintegrationhub/iam-utils": "*",
+				"amqplib": "^0.10.3",
 				"backend-commons-lib": "*",
 				"basic-auth": "2.0.1",
 				"bunyan": "1.8.14",
@@ -58738,6 +58873,7 @@
 				"node-fetch": "2.6.1",
 				"nodemon": "2.0.4",
 				"nyc": "15.1.0",
+				"promise-toolbox": "^0.21.0",
 				"rabbitmq-stats": "1.2.3",
 				"request": "2.88.2",
 				"sinon": "9.0.3",
@@ -58779,6 +58915,17 @@
 					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
 					"integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
 					"dev": true
+				},
+				"amqplib": {
+					"version": "0.10.3",
+					"resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.3.tgz",
+					"integrity": "sha512-UHmuSa7n8vVW/a5HGh2nFPqAEr8+cD4dEZ6u9GjP91nHfr1a54RyAKyra7Sb5NH7NBKOUlyQSMXIp0qAixKexw==",
+					"requires": {
+						"@acuminous/bitsyntax": "^0.1.2",
+						"buffer-more-ints": "~1.0.0",
+						"readable-stream": "1.x >=1.1.9",
+						"url-parse": "~1.5.10"
+					}
 				},
 				"ansi-styles": {
 					"version": "4.3.0",
@@ -59079,6 +59226,14 @@
 								"has-flag": "^3.0.0"
 							}
 						}
+					}
+				},
+				"promise-toolbox": {
+					"version": "0.21.0",
+					"resolved": "https://registry.npmjs.org/promise-toolbox/-/promise-toolbox-0.21.0.tgz",
+					"integrity": "sha512-NV8aTmpwrZv+Iys54sSFOBx3tuVaOBvvrft5PNppnxy9xpU/akHbaWIril22AB22zaPgrgwKdD0KsrM0ptUtpg==",
+					"requires": {
+						"make-error": "^1.3.2"
 					}
 				},
 				"qs": {

--- a/services/component-orchestrator/config/default.json
+++ b/services/component-orchestrator/config/default.json
@@ -18,5 +18,5 @@
     "KUBERNETES_VOLUME_HOSTPATH_MOUNTPATH": "",
     "DATAHUB_BASE_URL": "http://data-hub-service.oih-dev-ns.svc.cluster.local:1234",
     "COMPONENT_LOG_LEVEL": "info",
-    "COMPONENT_PREFETCH_COUNT": 1
+    "COMPONENT_PREFETCH_COUNT": "1"
 }

--- a/services/component-orchestrator/package.json
+++ b/services/component-orchestrator/package.json
@@ -15,13 +15,14 @@
     "start:container": "nodemon --watch src/ --watch ../../lib/backend-commons-lib/src --watch ../../lib/component-orchestrator/src | bunyan",
     "build": "echo \"No Build defined\"",
     "build:docker": "docker build -t openintegrationhub/component-orchestrator:${VERSION} -f Dockerfile ../../"
-  },
+   },
   "author": "elastic.io",
   "license": "APL-2.0",
   "dependencies": {
     "@openintegrationhub/component-orchestrator": "*",
     "@openintegrationhub/event-bus": "*",
     "@openintegrationhub/iam-utils": "*",
+    "amqplib": "^0.10.3",
     "backend-commons-lib": "*",
     "basic-auth": "2.0.1",
     "express": "4.17.1",
@@ -31,6 +32,7 @@
     "lru-cache": "6.0.0",
     "mongoose": "6.10.3",
     "node-fetch": "2.6.1",
+    "promise-toolbox": "^0.21.0",
     "rabbitmq-stats": "1.2.3",
     "request": "2.88.2",
     "uuid": "8.3.0"


### PR DESCRIPTION
Previously the message was published directly to the component queue. This is to fix issue #1491 

**What has changed?**

- Added logic to publish to the component RabbitMQ exchange topic instead of directly to the component queue
- I was getting an error with the component orchestrator creating a Kubernetes secret related to `COMPONENT_PREFETCH_COUNT` being of type number. This could potentially be separated out if need be.

**Does a specific change require especially careful review?**

N/A

**What is still open or a known issue?**
N/A

**Release Notes**

Component Orchestrator will now publish messages to a topic which can be subscribed to by multiple consumers in multiple queues instead of publishing directly to the component queue