### PR TITLE
Make the max rebound queue TTL configurable

### DIFF
--- a/lib/ferryman/createQueues.js
+++ b/lib/ferryman/createQueues.js
@@ -108,7 +108,9 @@ function сreateQueuesAndExchanges(execId, task, stepId, nextStepId){
         }
     };
 
-    var REBOUND_QUEUE_TTL = 10 * 60 * 1000; // 10 min
+    const REBOUND_QUEUE_TTL_STRING = process.env.REBOUND_QUEUE_TTL;
+    var REBOUND_QUEUE_TTL = REBOUND_QUEUE_TTL_STRING && REBOUND_QUEUE_TTL_STRING.length > 0 ? 
+        parseInt(REBOUND_QUEUE_TTL_STRING) : (10 * 60 * 1000); // 10 min
 
     var reboundsQueue = {
         name: REBOUNDS_QUEUE,


### PR DESCRIPTION

**What has changed?**

- If unset, it defaults to 10 minutes as before.
- Currently the rebounding starts at 15s, doubles each retry and retries 20 times by default. Because the rebound queue TTL is set to 10 minutes, the rebound interval maxes out at 10 minutes. This means the rebound will timeout after ~2h 55m which is rather short.  This change will allow you to control the max TTL interval.
- If you set the TTL on the queue and the message the shorter of the 2 will be used https://www.rabbitmq.com/ttl.html#per-message-ttl-in-publishers. This is why once the message TTL gets larger than 10 minutes, RabbitMQ will use the queue TTL.

**Does a specific change require especially careful review?**
N/A

**What is still open or a known issue?**
N/A

**Release Notes**

The max interval TTL between rebounds is now configurable