### PR TITLE
Added tenant when the flow is created

### DIFF
--- a/services/flow-repository/app/api/controllers/flow.js
+++ b/services/flow-repository/app/api/controllers/flow.js
@@ -152,6 +152,9 @@ router.post('/', jsonParser, can(config.flowWritePermission), async (req, res) =
       if (newFlow.owners.findIndex((o) => (o.id === req.user.sub)) === -1) {
         newFlow.owners.push({ id: req.user.sub, type: 'user' });
       }
+      if (req.user.tenant && newFlow.owners.findIndex((o) => (o.id === req.user.tenant && o.type === 'tenant')) === -1) {
+        newFlow.owners.push({ id: req.user.tenant, type: 'tenant' });
+      }
 
       const storeFlow = new Flow(newFlow);
       const errors = validate(storeFlow);

--- a/services/flow-repository/package.json
+++ b/services/flow-repository/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-repository",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Stores and manages integration flows.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
**What has changed?**

- It has been added the tenant to the owners array when a flow is created. This is to be able to fetch all flows from a tenant because right now, when the query is built, it checks within the owners that the tenant is in the array.
