### PR TITLE
HMAC auth on secret-service returns 413 https status code 

### DIFF
--- a/services/secret-service/package.json
+++ b/services/secret-service/package.json
@@ -21,6 +21,7 @@
     "@openintegrationhub/iam-utils": "*",
     "assert": "2.0.0",
     "base64url": "3.0.1",
+    "body-parser": "^1.20.2",
     "cors": "2.8.5",
     "dot-prop": "5.2.0",
     "dotenv": "8.2.0",
@@ -37,7 +38,6 @@
     "uuid": "8.3.2"
   },
   "devDependencies": {
-    "nodemon": "2.0.4",
     "eslint": "7.32.0",
     "eslint-config-airbnb-base": "14.2.1",
     "eslint-plugin-import": "2.22.1",
@@ -46,6 +46,7 @@
     "mongodb": "3.6.3",
     "mongodb-memory-server": "7.4.0",
     "nock": "13.0.5",
+    "nodemon": "2.0.4",
     "supertest": "6.0.1"
   },
   "jest": {

--- a/services/secret-service/src/conf/index.js
+++ b/services/secret-service/src/conf/index.js
@@ -52,4 +52,5 @@ module.exports = {
         defaultPage: parseInt(optional('PAGINATION_DEFAULT_PAGE', 1), 10), // default page is 1
         pageSize: parseInt(optional('PAGINATION_PAGE_SIZE', 30), 10), // show 10 items per page
     },
+    bodyParserLimit: optional('BODY_PARSER_LIMIT', '1MB'),
 };

--- a/services/secret-service/src/server/index.js
+++ b/services/secret-service/src/server/index.js
@@ -14,7 +14,7 @@ const conf = require('../conf');
 const AuthClientRouter = require('../route/auth-clients');
 const SecretsRouter = require('../route/secrets');
 
-const jsonParser = bodyParser.json();
+const jsonParser = bodyParser.json({ limit: conf.bodyParserLimit });
 
 module.exports = class Server {
     constructor({


### PR DESCRIPTION
when body is larger than 100kb https://www.npmjs.com/package/body-parser#bodyparserjsonoptions

**What has changed?**

- I changed the default to 1mb and made the value configurable.
- I also noticed body-parser wasn't listed as a dependency in the package.json and added it

**Does a specific change require especially careful review?**
N/A

**What is still open or a known issue?**
N/A

**Release Notes**
Made secret-service request body limit configurable