### PR TITLE
Allow to filter flows by user

### DIFF
--- a/services/flow-repository/app/api/controllers/flow.js
+++ b/services/flow-repository/app/api/controllers/flow.js
@@ -76,9 +76,6 @@ router.get('/', jsonParser, can(config.flowReadPermission), async (req, res) => 
 
   // filter[user]
   if (req.query.filter && req.query.filter.user !== undefined) {
-    if (!req.user.isAdmin) {
-      return res.status(403).send({ errors: [{ message: 'Filtering by user is only available to admins', code: 403 }] });
-    }
     filters.user = req.query.filter.user;
   }
 

--- a/services/flow-repository/app/api/swagger/swagger.json
+++ b/services/flow-repository/app/api/swagger/swagger.json
@@ -78,7 +78,7 @@
           {
             "name": "filter[user]",
             "in": "query",
-            "description": "Filter by user. Works for admin or users with same tenant.",
+            "description": "Filter by user. Works for users within the same tenant.",
             "required": false,
             "schema": {
               "type": "string"

--- a/services/flow-repository/package.json
+++ b/services/flow-repository/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-repository",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Stores and manages integration flows.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
**What has changed?**

- Removed restriction for user filter in flows repo, so that users within the same tenant can get flows.

**Release Notes**

Allow ordinary users to filter flows by user.
