### PR TITLE
Use externalExecId in Component Orchestrator

### DIFF
--- a/lib/component-orchestrator/package.json
+++ b/lib/component-orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openintegrationhub/component-orchestrator",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Orchestrates cluster resources",
   "main": "src/index.js",
   "scripts": {

--- a/lib/component-orchestrator/src/ComponentOrchestrator.js
+++ b/lib/component-orchestrator/src/ComponentOrchestrator.js
@@ -1,7 +1,8 @@
 const { Event } = require('@openintegrationhub/event-bus');
 const { v1, v4 } = require('uuid');
 const jwt = require('jsonwebtoken');
-const {Amqp} = require('./amqp');
+const { Amqp } = require('./amqp');
+const _ = require('lodash');
 
 const orchestratorId = `orchestrator-${v1()}`
 
@@ -568,7 +569,8 @@ class ComponentOrchestrator {
         const stepId = firstNode.id;
         const component = await this._componentsDao.findById(firstNode.componentId);
 
-        const flowExecId = v4()
+        const externalExecId = _.get(msg, 'metadata.source.externalExecId');
+        const flowExecId = externalExecId || v4();
 
         await this._flowStateDao.upsertCount(flow._id, flowExecId, 1, 0)
 

--- a/services/component-orchestrator/package.json
+++ b/services/component-orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-orchestrator",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Resource coordinator",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
**What has changed?**

- Use externalExecId in Component Orchestrator so that it corresponds to the requestId e.g. from webhooks.