### PR TITLE
feat: new adapter preprocessor for zoom

### DIFF
--- a/services/secret-service/index.js
+++ b/services/secret-service/index.js
@@ -36,6 +36,7 @@ process.on('SIGINT', exitHandler.bind(null));
                     microsoft: require('./src/adapter/preprocessor/microsoft'),
                     oidc: require('./src/adapter/preprocessor/oidc'),
                     azure: require('./src/adapter/preprocessor/azure'),
+                    zoom: require('./src/adapter/preprocessor/zoom'),
                 },
             },
             eventBus,

--- a/services/secret-service/src/adapter/preprocessor/zoom/index.js
+++ b/services/secret-service/src/adapter/preprocessor/zoom/index.js
@@ -1,0 +1,19 @@
+const rp = require('request-promise');
+
+module.exports = async ({
+    secret,
+    tokenResponse,
+}) => {
+    const resp = await rp.get({
+        uri: 'https://api.zoom.us/v2/users/me',
+        headers: {
+            Authorization: tokenResponse.access_token,
+        },
+        json: true,
+    });
+
+    secret.value.externalId = resp.id;
+    secret.value.externalAccountId = resp.account_id;
+
+    return secret;
+};

--- a/services/secret-service/src/adapter/preprocessor/zoom/index.js
+++ b/services/secret-service/src/adapter/preprocessor/zoom/index.js
@@ -1,19 +1,16 @@
 const rp = require('request-promise');
 
-module.exports = async ({
-    secret,
-    tokenResponse,
-}) => {
+module.exports = async ({ secret, tokenResponse }) => {
+    const authToken = `Bearer ${tokenResponse.access_token}`;
     const resp = await rp.get({
         uri: 'https://api.zoom.us/v2/users/me',
         headers: {
-            Authorization: tokenResponse.access_token,
+            Authorization: authToken,
         },
         json: true,
     });
 
     secret.value.externalId = resp.id;
-    secret.value.externalAccountId = resp.account_id;
 
     return secret;
 };


### PR DESCRIPTION
**What has changed?**
All of the changes are in the secret service
* Added Zoom preprocessor to capture the id property from the user

**Does a specific change require especially careful review?**
NA
- Change Add Zoom Preprocessor
  - Why?
  - Zoom requires a Deauthorization endpoint. This endpoint will notify our platform that the user has uninstalled the application and as consequence we will need to deauthorise them also in our platform. For this purpose, we need to recover the user_id of each user and store it as externalId to be able to recover it later [Zoom documentation](https://developers.zoom.us/docs/distribute/app-submission/submission-checklist/#8-provide-a-deauthorization-event-url-for-testing)

- What files are affected?
	- New adapter: preprocessor/zoom/index.js
	- secret-service/index.js

**What is still open or a known issue?**
None
**Release Notes**
- Added Zoom preprocessor to capture user_id 

