### PR TITLE
ferryman: take headers params from tokenData

### DIFF
--- a/lib/ferryman/lib/ferryman.js
+++ b/lib/ferryman/lib/ferryman.js
@@ -643,7 +643,6 @@ class Ferryman {
             this.nodeSettings = tokenData.nodeSettings;
             this.apiKey = tokenData.apiKey;
             this.apiUsername = tokenData.apiUsername;
-
             this.snapshotRoutingKey = tokenData.snapshotRoutingKey;
         } else {
             log.warn('Could not decode jwt!');
@@ -783,13 +782,13 @@ class Ferryman {
             'threadId': incomingMessageHeaders.threadId,
             'messageId': outgoingMessageId,
             'execId': settings.EXEC_ID,
-            'taskId': this.flowId, // message.properties.headers.taskId, // settings.FLOW_ID,
+            'taskId': tokenData.flowId,
             'workspaceId': settings.WORKSPACE_ID,
             'containerId': settings.CONTAINER_ID,
-            'userId': this.userId, // message.properties.headers.userId, // settings.USER_ID,
-            'stepId': this.stepId, // message.properties.headers.stepId, // settings.STEP_ID,
+            'userId': tokenData.userId,
+            'stepId': tokenData.stepId,
             'compId': settings.COMP_ID,
-            'function': this.function,
+            'function': tokenData.function,
             'start': new Date().getTime(),
             'cid': cipher.id,
             'x-eio-routing-key': routingKey,

--- a/lib/ferryman/package.json
+++ b/lib/ferryman/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openintegrationhub/ferryman",
   "description": "Wrapper utility for Open Integration Hub connectors",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "main": "run.js",
   "scripts": {
     "lint": "eslint lib mocha_spec lib runGlobal.js runService.js",


### PR DESCRIPTION
**What has changed?**

- Take params from `tokenData`, because they were accessed like `this.flowId` it led to the problem, that they were shared between different messages (different flowId, stepId, etc.). As a result snapshot was published with wrong headers, leading snapshot to function incorrectly.