### PR TITLE
Re-enabled passthrough functionality in ferryman

### DIFF
--- a/lib/ferryman/lib/ferryman.js
+++ b/lib/ferryman/lib/ferryman.js
@@ -436,7 +436,7 @@ class Ferryman {
     }
 
     scheduleShutdown() {
-    // eslint-disable-next-line consistent-return
+        // eslint-disable-next-line consistent-return
         return co(function* doScheduleShutdown() {
             if (this.shutdownCallback) {
                 log.info('scheduleShutdown – shutdown is already scheduled, do nothing');
@@ -626,8 +626,8 @@ class Ferryman {
 
         // Prepare depending on message
         if (!message.properties
-      || !message.properties.headers
-      || !message.properties.headers.orchestratorToken
+            || !message.properties.headers
+            || !message.properties.headers.orchestratorToken
         ) {
             console.error('No orchestratorToken!');
             return;
@@ -653,7 +653,7 @@ class Ferryman {
         }
 
         if (this.nodeSettings && this.nodeSettings.applyTransform
-          && (this.nodeSettings.applyTransform === 'before' || this.nodeSettings.applyTransform === 'both')) {
+            && (this.nodeSettings.applyTransform === 'before' || this.nodeSettings.applyTransform === 'both')) {
             const transformCfg = {
                 customMapping: this.nodeSettings.transformFunction
             };
@@ -833,8 +833,8 @@ class Ferryman {
 
                 const currentApplicationUid = (
                     passedCfg
-                  && passedCfg.nodeSettings
-                  && passedCfg.nodeSettings.applicationUid
+                    && passedCfg.nodeSettings
+                    && passedCfg.nodeSettings.applicationUid
                 ) ? passedCfg.nodeSettings.applicationUid
                     : ((data && data.metadata) ? data.metadata.applicationUid : null);
 
@@ -848,27 +848,16 @@ class Ferryman {
 
                 headers.end = new Date().getTime();
 
-                if (stepData.is_passthrough === true) {
-                    if (settings.NO_SELF_PASSTRHOUGH) {
-                        // eslint-disable-next-line
-                        const { stepId } = this.stepId; // incomingMessageHeaders;
-                        if (stepId) {
-                            // eslint-disable-next-line no-param-reassign
-                            data.passthrough = Object.assign({}, origPassthrough, {
-                                [stepId]: Object.assign({}, _.omit(payload, 'passthrough'))
-                            });
-                        }
-                    } else {
-                        // eslint-disable-next-line no-param-reassign
-                        data.passthrough = Object.assign({}, origPassthrough, {
-                            [self.settings.STEP_ID]: Object.assign({}, _.omit(data, 'passthrough'))
-                        });
-                    }
+                if (passedCfg && passedCfg.nodeSettings && passedCfg.nodeSettings.passthrough) {
+                    // eslint-disable-next-line no-param-reassign
+                    data.passthrough = Object.assign({}, origPassthrough, {
+                        [tokenData.stepId]: Object.assign({}, _.omit(data, 'passthrough'))
+                    });
                 }
 
                 if (passedCfg.nodeSettings && passedCfg.nodeSettings.applyTransform
                     && (passedCfg.nodeSettings.applyTransform === 'after'
-                      || passedCfg.nodeSettings.applyTransform === 'both')
+                        || passedCfg.nodeSettings.applyTransform === 'both')
                 ) {
                     const transformCfg = {
                         customMapping: passedCfg.nodeSettings.secondTransformFunction
@@ -960,8 +949,8 @@ class Ferryman {
 
                     if (
                         passedCfg.nodeSettings
-                      && typeof (passedCfg.nodeSettings === 'object')
-                      && passedCfg.nodeSettings.governance
+                        && typeof (passedCfg.nodeSettings === 'object')
+                        && passedCfg.nodeSettings.governance
                     ) {
                         const oihUid = (data.metadata && data.metadata.oihUid)
                             ? data.metadata.oihUid : savedMeta.oihUid;
@@ -991,7 +980,7 @@ class Ferryman {
                             }
                         }
 
-                      await self.generateProvenanceEvent({ // eslint-disable-line
+                        await self.generateProvenanceEvent({ // eslint-disable-line
                             oihUid: oihUid,
                             recordUid: savedMeta.recordUid,
                             deleteType,
@@ -1158,7 +1147,7 @@ class Ferryman {
                 }, 'processMessage emit end');
 
                 const headers = _.clone(outgoingMessageHeaders);
-                self.amqpConnection.sendFunctionComplete(headers,null);
+                self.amqpConnection.sendFunctionComplete(headers, null);
                 resolve();
             }
         });

--- a/lib/ferryman/package.json
+++ b/lib/ferryman/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openintegrationhub/ferryman",
   "description": "Wrapper utility for Open Integration Hub connectors",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "main": "run.js",
   "scripts": {
     "lint": "eslint lib mocha_spec lib runGlobal.js runService.js",


### PR DESCRIPTION
**What has changed?**

- Fixed passthrough functionality in ferryman to work with current architecture
- Setting `nodeSettings.passthrough = true` will now append the current step's emitted data into the message's passthrough property
- Passthrough data is available in all subsequent steps of a flow