### PR TITLE
Fixed a bug where emitting without recordUid would cause metadata to be lost

### DIFF
--- a/lib/ferryman/lib/ferryman.js
+++ b/lib/ferryman/lib/ferryman.js
@@ -883,13 +883,10 @@ class Ferryman {
                     && passedCfg.nodeSettings.idLinking
                 ) {
 
-                    let oihMeta = {};
-                    if (data.metadata && data.metadata.recordUid) {
-                        oihMeta = {
-                            oihUid: data.metadata.oihUid,
-                            recordUid: data.metadata.recordUid
-                        };
-                    }
+                    const oihMeta = {
+                        oihUid: data.metadata.oihUid,
+                        recordUid: data.metadata.recordUid
+                    };
 
                     const getIdMetaResult = await self.getIdMeta(oihMeta, self, tokenData.apiKey);
 

--- a/lib/ferryman/package.json
+++ b/lib/ferryman/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openintegrationhub/ferryman",
   "description": "Wrapper utility for Open Integration Hub connectors",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "main": "run.js",
   "scripts": {
     "lint": "eslint lib mocha_spec lib runGlobal.js runService.js",


### PR DESCRIPTION
**What has changed?**

- In cases where a step with enabled IDLinking emits a message without a recordUid, the entire metadata package would be lost
- This is relevant in flows with several chained actions where not every action necessarily produces an output