### PR TITLE
Changed action variable to be taken directly from tokenData instead o…

### DIFF
--- a/lib/ferryman/lib/ferryman.js
+++ b/lib/ferryman/lib/ferryman.js
@@ -768,10 +768,9 @@ class Ferryman {
             _.assign(cfg, secret);
         }
 
-        // TODO: Determine whether setting value can/should be disregarded entirely
-        const action = this.function || settings.FUNCTION;
+        const action = tokenData.function;
 
-        logger.trace('Trigger or action: %s', action);
+        logger.info('Trigger or action: %s', action);
 
         // this.flowId this.stepId
 

--- a/lib/ferryman/package.json
+++ b/lib/ferryman/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openintegrationhub/ferryman",
   "description": "Wrapper utility for Open Integration Hub connectors",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "main": "run.js",
   "scripts": {
     "lint": "eslint lib mocha_spec lib runGlobal.js runService.js",


### PR DESCRIPTION
**What has changed?**

- When running a global connector, there was a small chance that two flows executing at nearly the same time could influence which function name the other executes
- This would generally lead to the flow with the wrong function failing
- The cause of this was the function name being assigned to and read from the Ferryman class, so simultaneous executions caused a race condition here
- Simply reading the function name directly from the tokenData fixes this.